### PR TITLE
Feat/update conf

### DIFF
--- a/boilerplate/source/conf.py
+++ b/boilerplate/source/conf.py
@@ -153,6 +153,28 @@ hoverxref_mathjax = True
 
 
 def skip_submodules(app, what, name, obj, skip, options):
+    """Function used by ``autoapi-skip-member`` event to skip submodules.
+
+    Parameters
+    ----------
+    app : Sphinx
+        The Sphinx application object.
+    what : str
+        The type of the member.
+    name : str
+        The name of the member (like ``module.Class.attribute`` for instance).
+    obj : object
+        The Sphinx object representing the member.
+    skip : bool
+        Whether the member should be skipped (at this point, from the configuration).
+    options : list[str]
+        The options passed to the directive from ``conf.py``.
+
+    Returns
+    -------
+    bool
+        Whether the member should be skipped.
+    """
     if what == "attribute":
         if obj.is_undoc_member:
             print(f"  • Skipping {what} {name} because it is not documented.")
@@ -161,6 +183,13 @@ def skip_submodules(app, what, name, obj, skip, options):
 
 
 def setup(sphinx):
+    """Function to setup the Sphinx application.
+
+    Parameters
+    ----------
+    sphinx : Sphinx
+        The Sphinx application object.
+    """
     sphinx.connect("autoapi-skip-member", skip_submodules)
 
 

--- a/boilerplate/source/conf.py
+++ b/boilerplate/source/conf.py
@@ -145,3 +145,24 @@ hoverxref_mathjax = True
 #     "enable": True,
 #     # "image": "./_static/images/logo.png",
 # }
+
+# :entaldocs: <update>
+# DO NOT change what is between <update> and </update>
+# it may be overwritten in subsequent `entaldocs update` calls
+# ----------------------------X---------------------------------
+
+
+def skip_submodules(app, what, name, obj, skip, options):
+    if what == "attribute":
+        if obj.is_undoc_member:
+            print(f"  • Skipping {what} {name} because it is not documented.")
+            return True
+    return skip
+
+
+def setup(sphinx):
+    sphinx.connect("autoapi-skip-member", skip_submodules)
+
+
+# ----------------------------X---------------------------------
+# :entaldocs: </update>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -148,3 +148,53 @@ hoverxref_mathjax = True
 #     "enable": True,
 #     # "image": "./_static/images/logo.png",
 # }
+
+# :entaldocs: <update>
+# DO NOT change what is between <update> and </update>
+# it may be overwritten in subsequent `entaldocs update` calls
+# ----------------------------X---------------------------------
+
+
+def skip_submodules(app, what, name, obj, skip, options):
+    """Function used by ``autoapi-skip-member`` event to skip submodules.
+
+    Parameters
+    ----------
+    app : Sphinx
+        The Sphinx application object.
+    what : str
+        The type of the member.
+    name : str
+        The name of the member (like ``module.Class.attribute`` for instance).
+    obj : object
+        The Sphinx object representing the member.
+    skip : bool
+        Whether the member should be skipped (at this point, from the configuration).
+    options : list[str]
+        The options passed to the directive from ``conf.py``.
+
+    Returns
+    -------
+    bool
+        Whether the member should be skipped.
+    """
+    if what == "attribute":
+        if obj.is_undoc_member:
+            print(f"  • Skipping {what} {name} because it is not documented.")
+            return True
+    return skip
+
+
+def setup(sphinx):
+    """Function to setup the Sphinx application.
+
+    Parameters
+    ----------
+    sphinx : Sphinx
+        The Sphinx application object.
+    """
+    sphinx.connect("autoapi-skip-member", skip_submodules)
+
+
+# ----------------------------X---------------------------------
+# :entaldocs: </update>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -148,3 +148,25 @@ hoverxref_mathjax = True
 #     "enable": True,
 #     # "image": "./_static/images/logo.png",
 # }
+
+
+# :entaldocs: <update>
+# DO NOT change what is between <update> and </update>
+# it may be overwritten in subsequent `entaldocs update` calls
+# ----------------------------X---------------------------------
+
+
+def skip_submodules(app, what, name, obj, skip, options):
+    if what == "attribute":
+        if obj.is_undoc_member:
+            print(f"  • Skipping {what} {name} because it is not documented.")
+            return True
+    return skip
+
+
+def setup(sphinx):
+    sphinx.connect("autoapi-skip-member", skip_submodules)
+
+
+# ----------------------------X---------------------------------
+# :entaldocs: </update>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -148,25 +148,3 @@ hoverxref_mathjax = True
 #     "enable": True,
 #     # "image": "./_static/images/logo.png",
 # }
-
-
-# :entaldocs: <update>
-# DO NOT change what is between <update> and </update>
-# it may be overwritten in subsequent `entaldocs update` calls
-# ----------------------------X---------------------------------
-
-
-def skip_submodules(app, what, name, obj, skip, options):
-    if what == "attribute":
-        if obj.is_undoc_member:
-            print(f"  • Skipping {what} {name} because it is not documented.")
-            return True
-    return skip
-
-
-def setup(sphinx):
-    sphinx.connect("autoapi-skip-member", skip_submodules)
-
-
-# ----------------------------X---------------------------------
-# :entaldocs: </update>

--- a/entaldocs/cli.py
+++ b/entaldocs/cli.py
@@ -255,20 +255,22 @@ def update(path: str = "./docs", branch: str = "main", contents: str = "boilerpl
     path = resolve_path(path)
     if not path.exists():
         logger.abort(f"Path not found: {path}", exit=1)
-    if not logger.confirm("This will overwrite the static files. Continue?"):
-        logger.abort("Aborting.", exit=1)
-    static = path / "source" / "_static"
-    if not static.exists():
-        logger.abort(f"Static folder not found: {static}", exit=1)
-    copy_boilerplate(
-        dest=path,
-        branch=branch,
-        content_path=contents,
-        overwrite=False,
-        include_files_regex="_static",
-    )
-    update_conf_py(path, branch=branch)
-    logger.success("Static files updated.")
+    if logger.confirm("This will overwrite the static files. Continue?"):
+        static = path / "source" / "_static"
+        if not static.exists():
+            logger.abort(f"Static folder not found: {static}", exit=1)
+        copy_boilerplate(
+            dest=path,
+            branch=branch,
+            content_path=contents,
+            overwrite=False,
+            include_files_regex="_static",
+        )
+        logger.success("Static files updated.")
+    if logger.confirm("Would you like to update the conf.py file?"):
+        update_conf_py(path, branch=branch)
+        logger.success("[r]conf.py[/r] updated.")
+    logger.success("Done.")
 
 
 @_app.command

--- a/entaldocs/cli.py
+++ b/entaldocs/cli.py
@@ -31,6 +31,7 @@ from entaldocs.utils import (
     make_empty_folders,
     overwrite_docs_files,
     resolve_path,
+    update_conf_py,
 )
 
 _app = App(
@@ -259,7 +260,14 @@ def update(path: str = "./docs", branch: str = "main", contents: str = "boilerpl
     static = path / "source" / "_static"
     if not static.exists():
         logger.abort(f"Static folder not found: {static}", exit=1)
-    copy_boilerplate(dest=path, branch=branch, content_path=contents, overwrite=False)
+    copy_boilerplate(
+        dest=path,
+        branch=branch,
+        content_path=contents,
+        overwrite=False,
+        include_files_regex="_static",
+    )
+    update_conf_py(path, branch=branch)
     logger.success("Static files updated.")
 
 
@@ -302,4 +310,5 @@ def set_github_pat(pat: Optional[str] = ""):
         pat = logger.prompt("Enter your GitHub PAT")
     logger.confirm("Are you sure you want to set the GitHub PAT?")
     set_password("entaldocs", "github_pat", pat)
+    logger.success("GitHub PAT set.")
     logger.success("GitHub PAT set.")

--- a/entaldocs/utils.py
+++ b/entaldocs/utils.py
@@ -205,7 +205,7 @@ def update_conf_py(dest: Path, branch: str = "main"):
             dest_content = re.sub(pattern, replacement, dest_content, re.DOTALL)
         else:
             # pattern does not exist, add it
-            dest_content += f"\n{replacement}"
+            dest_content += f"\n{replacement}\n"
 
         # write the updated content to the destination file
         dest.write_text(dest_content)
@@ -397,6 +397,8 @@ def search_contents(
 
     """
     contents = repo.get_contents(content_path, ref=branch)
+    if not isinstance(contents, list):
+        contents = [contents]
 
     # If we don't ajust the content path, fetching a folder will include the full content
     # path and the files will be copied to the wrong location:
@@ -423,9 +425,13 @@ def search_contents(
         else:
             logger.clear_line()
             print(f"Getting contents of '{file_content.path}'", end="\r")
+            # adjust file path
+            new_relative_path = file_content.path.replace(extra_path, "")
+            if new_relative_path.startswith("/"):
+                new_relative_path = new_relative_path[1:]
             data.append(
                 (
-                    file_content.path.replace(extra_path, ""),  # adjust file path
+                    new_relative_path,
                     file_content.decoded_content,
                 )
             )
@@ -437,7 +443,7 @@ def search_contents(
 def fetch_github_files(
     branch: str = "main", content_path: str = "boilerplate", dir: str = "."
 ) -> Path:
-    """Download a file or directory from a GitHub repository.
+    """Download a file or directory from a GitHub repository and write it to ``dir``.
 
     Parameters
     ----------

--- a/entaldocs/utils.py
+++ b/entaldocs/utils.py
@@ -193,19 +193,22 @@ def update_conf_py(dest: Path, branch: str = "main"):
         dest_content = dest.read_text()
         # get the content between the start and end patterns in the source file
         pattern = f"{start_pattern}(.+){end_pattern}"
-        incoming = re.search(pattern, src_content, re.DOTALL)
+        incoming = re.search(pattern, src_content, flags=re.DOTALL)
         if not incoming:
             return
         incoming = incoming.group(1)
 
         # replace the content between the start and end patterns in the destination file
         replacement = f"{start_pattern}{incoming}{end_pattern}"
-        if re.search(pattern, dest_content, re.DOTALL):
+        if re.search(pattern, dest_content, flags=re.DOTALL):
             # pattern exists, replace it
-            dest_content = re.sub(pattern, replacement, dest_content, re.DOTALL)
+            dest_content = re.sub(pattern, replacement, dest_content, flags=re.DOTALL)
         else:
             # pattern does not exist, add it
             dest_content += f"\n{replacement}\n"
+
+        if not dest_content.endswith("\n"):
+            dest_content += "\n"
 
         # write the updated content to the destination file
         dest.write_text(dest_content)


### PR DESCRIPTION
Add a mechanism to update the `conf.py` file.

Typically add a section between `# :entaldocs: <update>` and `# :entaldocs: </update>` comments. Subsequent calls to `entaldoc updates` will overwrite this section of the config. One can choose not to inherit this configuration section by saying `N` to the prompt asking for confirmation.

```
# :entaldocs: <update>
# DO NOT change what is between <update> and </update>
# it may be overwritten in subsequent `entaldocs update` calls
# ----------------------------X---------------------------------


def skip_submodules(app, what, name, obj, skip, options):
    """Function used by ``autoapi-skip-member`` event to skip submodules.

    Parameters
    ----------
    app : Sphinx
        The Sphinx application object.
    what : str
        The type of the member.
    name : str
        The name of the member (like ``module.Class.attribute`` for instance).
    obj : object
        The Sphinx object representing the member.
    skip : bool
        Whether the member should be skipped (at this point, from the configuration).
    options : list[str]
        The options passed to the directive from ``conf.py``.

    Returns
    -------
    bool
        Whether the member should be skipped.
    """
    if what == "attribute":
        if obj.is_undoc_member:
            print(f"  • Skipping {what} {name} because it is not documented.")
            return True
    return skip


def setup(sphinx):
    """Function to setup the Sphinx application.

    Parameters
    ----------
    sphinx : Sphinx
        The Sphinx application object.
    """
    sphinx.connect("autoapi-skip-member", skip_submodules)


# ----------------------------X---------------------------------
# :entaldocs: </update>
```