### PR TITLE
fix: Inherit docstring from top classes rather than __init__

### DIFF
--- a/boilerplate/source/conf.py
+++ b/boilerplate/source/conf.py
@@ -99,7 +99,7 @@ autoapi_dirs = []  # list of paths to the packages to document
 autoapi_ignore = ["*.venv/*", "*/tests/*", "*/boilerplate/*"]
 autoapi_member_order = "bysource"
 autoapi_template_dir = "_templates/autoapi"
-autoapi_python_class_content = "init"
+autoapi_python_class_content = "class"
 autoapi_options = [
     "members",
     "undoc-members",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -104,7 +104,7 @@ autoapi_dirs = ["../../src/entaldocs"]  # list of paths to the packages to docum
 autoapi_ignore = ["*.venv/*", "*/tests/*", "*boilerplate/*"]
 autoapi_member_order = "bysource"
 autoapi_template_dir = "_templates/autoapi"
-autoapi_python_class_content = "init"
+autoapi_python_class_content = "class"
 autoapi_options = [
     "members",
     "undoc-members",


### PR DESCRIPTION
This small fix addresses the issue where the generated docs of a class which inherited from a parent class was not parsed if the docstring was not inside the `__init__` function. 

The solution was to change the [`autoapi_python_class_content`](https://sphinx-autoapi.readthedocs.io/en/latest/reference/config.html#confval-autoapi_python_class_content) parameter of `autoapi` from  `init` to `class`.