### PR TITLE
chore: update precommit config

### DIFF
--- a/src/siesta/precommits.yaml
+++ b/src/siesta/precommits.yaml
@@ -1,5 +1,13 @@
 # Copyright 2025 Entalpic
 repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: check-yaml
+        args: ["--unsafe"]
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
     rev: v0.7.4
@@ -10,6 +18,6 @@ repos:
       - id: ruff-format
         args: [--check]
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.19.0
+    rev: v8.24.2
     hooks:
       - id: gitleaks


### PR DESCRIPTION
## Why

It seems the current version of gitleak was not properly supported: I got the following error when running on a new project:

```sh
○
    │╲
    │ ○
    ○ ░
    ░    gitleaks

10:43AM FTL flag accessed but not defined: source
```

## Changes

- This PR is updating the version of this hook. 

- It is as well proposing 3 other hooks that have been used in the [pathfinder_agent repository](https://github.com/Entalpic/pathfinder_agent/blob/develop/.pre-commit-config.yaml). This can be reverted to keep only the previous fix.
