### PR TITLE
Fix/get latest version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "siesta"
-version = "1.1.0"
+version = "1.1.1"
 description = "Entalpic's Development Guidelines & Docs CLI"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/siesta/cli.py
+++ b/src/siesta/cli.py
@@ -156,16 +156,19 @@ def main():
     """Run the CLI, gracefully handling ``KeyboardInterrupt``."""
     # Start background update check (non-blocking)
     update_future = start_background_update_check(metadata.version("siesta"))
+    interrupted = False
 
     try:
         app()
     except KeyboardInterrupt:
+        interrupted = True
         logger.abort("\nAborted.", exit=1)
     finally:
         # Show update message at the end (if available)
-        update_msg = get_update_message(update_future)
-        if update_msg:
-            logger.print(update_msg)
+        if not interrupted:
+            update_msg = get_update_message(update_future)
+            if update_msg:
+                logger.print(update_msg)
 
 
 @app.command(name="set-github-pat")

--- a/src/siesta/utils/self.py
+++ b/src/siesta/utils/self.py
@@ -29,10 +29,13 @@ from typing import TYPE_CHECKING
 from urllib.error import URLError
 from urllib.request import urlopen
 
+from github import Github, GithubException
+from github.Auth import Token
 from packaging.version import Version
 from platformdirs import user_cache_dir
 
 from siesta.utils.common import logger, run_command
+from siesta.utils.github import get_user_pat
 
 if TYPE_CHECKING:
     from typing import TypedDict
@@ -161,9 +164,6 @@ def _get_latest_version_github(timeout: float = 5.0) -> str | None:
     str | None
         The latest version string, or ``None`` if the query failed.
     """
-    from github import Github, GithubException
-
-    from siesta.utils.github import get_user_pat
 
     def try_get_version(g: Github) -> str | None:
         """Try to get version from releases, then tags."""
@@ -209,8 +209,6 @@ def _get_latest_version_github(timeout: float = 5.0) -> str | None:
     pat = get_user_pat()
     if pat:
         try:
-            from github.Auth import Token
-
             g = Github(auth=Token(pat), timeout=int(timeout))
             result = try_get_version(g)
             if result:

--- a/src/siesta/utils/self.py
+++ b/src/siesta/utils/self.py
@@ -105,7 +105,7 @@ def get_installation_method() -> str:
                 direct_url = json.loads(direct_url_text)
                 if direct_url.get("dir_info", {}).get("editable", False):
                     return "editable"
-        except FileNotFoundError:
+        except (FileNotFoundError, json.JSONDecodeError):
             pass
     except metadata.PackageNotFoundError:
         pass
@@ -139,7 +139,7 @@ def get_installation_source() -> str:
                 vcs_info = direct_url.get("vcs_info", {})
                 if vcs_info.get("vcs") == "git":
                     return "github"
-        except FileNotFoundError:
+        except (FileNotFoundError, json.JSONDecodeError):
             pass
     except metadata.PackageNotFoundError:
         pass

--- a/tests/test_cli/test_self.py
+++ b/tests/test_cli/test_self.py
@@ -11,6 +11,7 @@ from siesta.utils.self import (
     PACKAGE_NAME,
     compare_versions,
     get_installation_method,
+    get_installation_source,
     get_latest_version,
     get_update_command,
 )
@@ -74,35 +75,126 @@ class TestGetInstallationMethod:
             assert get_installation_method() == "pip"
 
 
+class TestGetInstallationSource:
+    """Tests for get_installation_source()."""
+
+    def test_detects_github_source(self):
+        """Test detection of GitHub (git) installation source."""
+        mock_dist = MagicMock()
+        mock_dist.read_text.return_value = (
+            '{"url": "git+ssh://git@github.com/entalpic/siesta.git", '
+            '"vcs_info": {"vcs": "git", "commit_id": "abc123"}}'
+        )
+
+        with patch("siesta.utils.self.metadata.distribution", return_value=mock_dist):
+            assert get_installation_source() == "github"
+
+    def test_detects_pypi_source_no_direct_url(self):
+        """Test detection of PyPI source when no direct_url.json exists."""
+        mock_dist = MagicMock()
+        mock_dist.read_text.side_effect = FileNotFoundError
+
+        with patch("siesta.utils.self.metadata.distribution", return_value=mock_dist):
+            assert get_installation_source() == "pypi"
+
+    def test_detects_pypi_source_no_vcs_info(self):
+        """Test detection of PyPI source when direct_url has no vcs_info."""
+        mock_dist = MagicMock()
+        mock_dist.read_text.return_value = (
+            '{"url": "https://files.pythonhosted.org/..."}'
+        )
+
+        with patch("siesta.utils.self.metadata.distribution", return_value=mock_dist):
+            assert get_installation_source() == "pypi"
+
+    def test_detects_pypi_source_editable(self):
+        """Test that editable installs are treated as pypi source."""
+        mock_dist = MagicMock()
+        mock_dist.read_text.return_value = '{"dir_info": {"editable": true}}'
+
+        with patch("siesta.utils.self.metadata.distribution", return_value=mock_dist):
+            assert get_installation_source() == "pypi"
+
+
 class TestGetLatestVersion:
     """Tests for get_latest_version()."""
 
-    def test_returns_version_on_success(self):
-        """Test successful version fetch from PyPI."""
+    def test_returns_version_from_pypi(self):
+        """Test successful version fetch from PyPI when source is pypi."""
         mock_response = MagicMock()
         mock_response.read.return_value = b'{"info": {"version": "2.0.0"}}'
         mock_response.__enter__ = MagicMock(return_value=mock_response)
         mock_response.__exit__ = MagicMock(return_value=False)
 
         with patch("siesta.utils.self.urlopen", return_value=mock_response):
-            assert get_latest_version() == "2.0.0"
+            assert get_latest_version(source="pypi") == "2.0.0"
 
-    def test_returns_none_on_network_error(self):
-        """Test None is returned on network failure."""
+    def test_returns_version_from_github_release(self):
+        """Test successful version fetch from GitHub releases."""
+        mock_release = MagicMock()
+        mock_release.tag_name = "v2.0.0"
+
+        mock_repo = MagicMock()
+        mock_repo.get_latest_release.return_value = mock_release
+
+        mock_github = MagicMock()
+        mock_github.get_repo.return_value = mock_repo
+
+        with patch("github.Github", return_value=mock_github):
+            assert get_latest_version(source="github") == "2.0.0"
+
+    def test_returns_version_from_github_tags_fallback(self):
+        """Test fallback to GitHub tags when no releases exist."""
+        from github import GithubException
+
+        mock_tag = MagicMock()
+        mock_tag.name = "v1.5.0"
+
+        mock_tags = MagicMock()
+        mock_tags.totalCount = 1
+        mock_tags.__getitem__ = MagicMock(return_value=mock_tag)
+
+        mock_repo = MagicMock()
+        mock_repo.get_latest_release.side_effect = GithubException(
+            404, "Not Found", None
+        )
+        mock_repo.get_tags.return_value = mock_tags
+
+        mock_github = MagicMock()
+        mock_github.get_repo.return_value = mock_repo
+
+        with patch("github.Github", return_value=mock_github):
+            assert get_latest_version(source="github") == "1.5.0"
+
+    def test_returns_none_on_pypi_network_error(self):
+        """Test None is returned on PyPI network failure."""
         from urllib.error import URLError
 
         with patch("siesta.utils.self.urlopen", side_effect=URLError("Network error")):
-            assert get_latest_version() is None
+            assert get_latest_version(source="pypi") is None
 
-    def test_returns_none_on_json_error(self):
-        """Test None is returned on invalid JSON response."""
+    def test_returns_none_on_pypi_json_error(self):
+        """Test None is returned on invalid JSON response from PyPI."""
         mock_response = MagicMock()
         mock_response.read.return_value = b"not valid json"
         mock_response.__enter__ = MagicMock(return_value=mock_response)
         mock_response.__exit__ = MagicMock(return_value=False)
 
         with patch("siesta.utils.self.urlopen", return_value=mock_response):
-            assert get_latest_version() is None
+            assert get_latest_version(source="pypi") is None
+
+    def test_auto_detects_source(self):
+        """Test that source is auto-detected when not specified."""
+        mock_response = MagicMock()
+        mock_response.read.return_value = b'{"info": {"version": "3.0.0"}}'
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch("siesta.utils.self.get_installation_source", return_value="pypi"),
+            patch("siesta.utils.self.urlopen", return_value=mock_response),
+        ):
+            assert get_latest_version() == "3.0.0"
 
 
 class TestCompareVersions:

--- a/tests/test_cli/test_self.py
+++ b/tests/test_cli/test_self.py
@@ -140,7 +140,7 @@ class TestGetLatestVersion:
         mock_github = MagicMock()
         mock_github.get_repo.return_value = mock_repo
 
-        with patch("github.Github", return_value=mock_github):
+        with patch("siesta.utils.self.Github", return_value=mock_github):
             assert get_latest_version(source="github") == "2.0.0"
 
     def test_returns_version_from_github_tags_fallback(self):
@@ -163,7 +163,7 @@ class TestGetLatestVersion:
         mock_github = MagicMock()
         mock_github.get_repo.return_value = mock_repo
 
-        with patch("github.Github", return_value=mock_github):
+        with patch("siesta.utils.self.Github", return_value=mock_github):
             assert get_latest_version(source="github") == "1.5.0"
 
     def test_returns_none_on_pypi_network_error(self):

--- a/uv.lock
+++ b/uv.lock
@@ -1522,7 +1522,7 @@ wheels = [
 
 [[package]]
 name = "siesta"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "cyclopts" },


### PR DESCRIPTION
## Fix `get_latest_version` to use installation source

`get_latest_version` now detects whether siesta was installed from GitHub or PyPI and queries the appropriate source for updates.

### Changes

- Add `get_installation_source()` to detect GitHub vs PyPI installation via `direct_url.json` metadata
- Add `_get_latest_version_github()` using PyGithub (tries unauthenticated first, falls back to PAT if rate-limited)
- Refactor `_get_latest_version_pypi()` for PyPI queries
- Update `get_latest_version()` to auto-detect source and route accordingly
- Add tests for new functionality
