### PR TITLE
feats: standalone test infrastructure, interactive flag, and promote `self`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,25 +14,31 @@ Use `siesta` to initialize
     siesta project quickstart --local
     ```
 
-2. Add documentation to an existing project
+2. Add testing infrastructure (pytest) to an _existing_ project
+
+    ```bash
+    siesta project setup-tests
+    ```
+
+3. Add documentation to an _existing_ project
 
     ```bash
     siesta docs init --local
     ```
 
-3. Build the docs locally
+4. Build the docs locally
 
     ```bash
     siesta docs build
     ```
 
-4. Watch for changes and auto-rebuild the docs
+5. Watch for changes and auto-rebuild the docs
 
     ```bash
     siesta docs watch
     ```
 
-5. Check for updates and upgrade siesta
+6. Check for updates and upgrade siesta
 
     ```bash
     siesta self version
@@ -82,6 +88,6 @@ That's it 🤓
 
 This is still very WIP. In particular, next steps:
 
-- Update Contribution Guide
-- Add ReadTheDocs deployment instructions
-- More tests
+-   Update Contribution Guide
+-   Add ReadTheDocs deployment instructions
+-   More tests

--- a/docs/source/guide/index.rst
+++ b/docs/source/guide/index.rst
@@ -27,8 +27,13 @@ It includes both the code's *docstrings* and the *manual documentation files* li
 
     .. code-block:: bash
 
+        # Start a new project from scratch
         siesta project quickstart
-        # or
+
+        # Add testing infrastructure to an existing project
+        siesta project setup-tests
+
+        # Add documentation to an existing project
         siesta docs init
 
     See :ref:`siesta-cli-tutorial` for more information.

--- a/src/siesta/__init__.py
+++ b/src/siesta/__init__.py
@@ -28,7 +28,7 @@ TL;DR
     $ siesta project quickstart --local
 
     # With most up to date remote files (requires GitHub PAT)
-    $ siesta set-github-pat
+    $ siesta self set-github-pat
     $ siesta project quickstart
 
 **Add documentation to an existing project:**
@@ -104,21 +104,16 @@ to access the files.
 
 .. code-block:: bash
 
-    $ siesta set-github-pat
+    $ siesta self set-github-pat
     $ siesta docs init --uv --with-defaults
 
 Going further
 =============
 
-Currently ``siesta`` has 5 main entry points with subcommands:
+Currently ``siesta`` has 3 main subcommands:
 
-**Top-level commands:**
-- ``set-github-pat`` to set your Github Personal Access Token (PAT) to access remote
-  files.
-- ``show-deps`` to show the dependencies that will be added to your project to make
-  docs.
+**``docs`` subcommands:**
 
-** ``docs`` subcommands:**
 - ``docs init`` to create a docs folder and get started with your current project's
   documentation.
 - ``docs build`` to build the HTML documentation locally (equivalent to running
@@ -126,15 +121,23 @@ Currently ``siesta`` has 5 main entry points with subcommands:
 - ``docs update`` to update the documentation boilerplate files in your project from Github. Typically updating the brand assets and colors.
 - ``docs watch`` to automatically build the docs when source files are changed.
 
-** ``project`` subcommands:**
+**``project`` subcommands:**
+
 - ``project quickstart`` to create a new Python project with ``uv`` and set up
   documentation as per ``docs init``.
+- ``project setup-tests`` to add pytest testing infrastructure to an existing project.
+- ``project tree`` to display the project's directory structure.
 
-** ``self`` subcommands:**
+**``self`` subcommands:**
+
 - ``self version`` to show the current siesta version and check for updates.
 - ``self update`` (or ``self upgrade``) to update siesta to the latest version.
   Automatically detects how siesta was installed (uv tool, pipx, pip) and uses the
   appropriate update command.
+- ``self set-github-pat`` to set your Github Personal Access Token (PAT) to access remote
+  files.
+- ``self show-deps`` to show the dependencies that will be added to your project to make
+  docs.
 
 .. note::
 
@@ -149,7 +152,7 @@ Currently ``siesta`` has 5 main entry points with subcommands:
 .. note::
 
     ``docs init`` and ``docs update`` require a Github Personal Access Token (PAT) to
-    access remote files. You can set it with ``$ siesta set-github-pat``. Alternatively,
+    access remote files. You can set it with ``$ siesta self set-github-pat``. Alternatively,
     you can use the ``--local`` flag to use local files instead of fetching from Github.
     Note that it may therefore not use the most up-to-date files to render the docs.
 

--- a/src/siesta/cli.py
+++ b/src/siesta/cli.py
@@ -26,9 +26,8 @@ Learn how to use with:
     $ siesta self # shows help
     $ siesta self version
     $ siesta self update  # or: siesta self upgrade
-
-    $ siesta set-github-pat
-    $ siesta show-deps
+    $ siesta self set-github-pat
+    $ siesta self show-deps
 
 You can also refer to the :ref:`siesta-cli-tutorial` for more information.
 
@@ -142,7 +141,9 @@ self_app = App(
     name="self",
     help=dedent(
         """
-        Manage siesta itself: check version, update to the latest release.
+        Manage siesta itself and configure settings.
+
+        Includes version checking, updates, GitHub PAT configuration, and dependency info.
 
         """.strip(),
     ),
@@ -173,7 +174,7 @@ def main():
                 logger.print(update_msg)
 
 
-@app.command(name="set-github-pat")
+@self_app.command(name="set-github-pat")
 def set_github_pat(pat: Optional[str] = ""):
     """
     Store a GitHub Personal Access Token (PAT) in your keyring.
@@ -206,7 +207,7 @@ def set_github_pat(pat: Optional[str] = ""):
     assert isinstance(pat, str), "PAT must be a string."
 
     logger.warning(
-        "Run [r]$ siesta set-github-pat --help[/r]"
+        "Run [r]$ siesta self set-github-pat --help[/r]"
         + " if you're not sure how to generate a PAT."
     )
     if not pat:
@@ -218,7 +219,7 @@ def set_github_pat(pat: Optional[str] = ""):
     logger.success("GitHub PAT set. You can now use `siesta docs init`.")
 
 
-@app.command(name="show-deps")
+@self_app.command(name="show-deps")
 def show_deps(as_pip: bool = False):
     """Show the recommended dependencies for the documentation that would be installed with `siesta docs init`.
 
@@ -255,7 +256,7 @@ def init_docs(
 
     - Initializes a new Sphinx project at the specified path.
 
-    - Optionally installs recommended dependencies (run `siesta show-deps` to see
+    - Optionally installs recommended dependencies (run ``siesta self show-deps`` to see
       them).
 
     - Uses the split source / build folder structure.
@@ -319,7 +320,9 @@ def init_docs(
             "You need to set a GitHub Personal Access Token"
             + " to fetch the latest static files."
         )
-        logger.warning("Run [r]$ siesta set-github-pat --help[/r] to learn how to.")
+        logger.warning(
+            "Run [r]$ siesta self set-github-pat --help[/r] to learn how to."
+        )
         logger.abort("Aborting.", exit=1)
 
     # Setting defaults: only fill in values that weren't explicitly provided
@@ -414,9 +417,9 @@ def update(
 
     .. important::
 
-        ``$ siesta update`` requires a GitHub Personal Access Token (PAT) to fetch
+        ``$ siesta docs update`` requires a GitHub Personal Access Token (PAT) to fetch
         the latest version of the documentation's static files etc. from the repository.
-        Run ``$ siesta set-github-pat`` to do so.
+        Run ``$ siesta self set-github-pat`` to do so.
 
     .. note::
 

--- a/src/siesta/cli.py
+++ b/src/siesta/cli.py
@@ -63,6 +63,7 @@ from siesta.utils.common import (
     run_command,
     write_or_update_pre_commit_file,
 )
+from siesta.utils.config import CLI_DEFAULTS
 from siesta.utils.docs import (
     AutoBuildDocs,
     copy_boilerplate,
@@ -324,9 +325,9 @@ def init_docs(
     # Setting defaults: only fill in values that weren't explicitly provided
     if not interactive:
         if deps is None:
-            deps = True
+            deps = CLI_DEFAULTS["deps"]
         if as_main_deps is None:
-            as_main_deps = False
+            as_main_deps = CLI_DEFAULTS["as_main_deps"]
 
     # Where the docs will be stored, typically `$CWD/docs`
     path = resolve_path(path)
@@ -703,21 +704,21 @@ def quickstart_project(
     # Setting defaults: only fill in values that weren't explicitly provided
     if not interactive:
         if precommit is None:
-            precommit = True
+            precommit = CLI_DEFAULTS["precommit"]
         if docs is None:
-            docs = True
+            docs = CLI_DEFAULTS["docs"]
         if deps is None:
-            deps = True
+            deps = CLI_DEFAULTS["deps"]
         if as_main_deps is None:
-            as_main_deps = False
+            as_main_deps = CLI_DEFAULTS["as_main_deps"]
         if ipdb is None:
-            ipdb = True
+            ipdb = CLI_DEFAULTS["ipdb"]
         if tests is None:
-            tests = True
+            tests = CLI_DEFAULTS["tests"]
         if actions is None:
-            actions = True
+            actions = CLI_DEFAULTS["actions"]
         if gitignore is None:
-            gitignore = True
+            gitignore = CLI_DEFAULTS["gitignore"]
 
     # Check if the project is already initialized
     has_uv_lock = Path("uv.lock").exists()
@@ -884,9 +885,9 @@ def setup_tests(
     # Setting defaults: only fill in values that weren't explicitly provided
     if not interactive:
         if actions is None:
-            actions = True
+            actions = CLI_DEFAULTS["actions"]
         if deps is None:
-            deps = True
+            deps = CLI_DEFAULTS["deps"]
 
     # Check if uv is available and uv.lock exists
     has_uv = Path("uv.lock").exists()

--- a/src/siesta/utils/common.py
+++ b/src/siesta/utils/common.py
@@ -1,7 +1,6 @@
 # Copyright 2025 Entalpic
 """Generalist utility functions."""
 
-import importlib
 import json
 import re
 from os.path import expandvars
@@ -12,11 +11,10 @@ from subprocess import CalledProcessError, run
 from ruamel.yaml import YAML
 
 from siesta.logger import Logger
+from siesta.utils.config import ROOT
 
 logger = Logger("siesta")
 """A logger to log messages to the console."""
-ROOT = importlib.resources.files("siesta")
-"""The root directory of the ``siesta`` package."""
 
 
 def safe_dump(data, file, **kwargs):

--- a/src/siesta/utils/common.py
+++ b/src/siesta/utils/common.py
@@ -180,7 +180,7 @@ def get_pyver():
     return "3.12"
 
 
-def get_project_name(with_defaults: bool, snake_case: bool = False) -> str:
+def get_project_name(interactive: bool = False, snake_case: bool = False) -> str:
     """Get the current project's name from the pyproject.toml or user.
 
     Prompts the user for the project name, with the default being the name in the pyproject.toml
@@ -188,8 +188,8 @@ def get_project_name(with_defaults: bool, snake_case: bool = False) -> str:
 
     Parameters
     ----------
-    with_defaults : bool
-        Whether to trust the defaults and skip all prompts.
+    interactive : bool, optional
+        Whether to prompt the user. Defaults to ``False`` (use defaults).
     snake_case : bool, optional
         Whether to convert the project name to snake case, by default ``False``.
 
@@ -204,7 +204,7 @@ def get_project_name(with_defaults: bool, snake_case: bool = False) -> str:
         txt = pyproject_toml.read_text()
         pyproject_name = re.search(r"name\s*=\s*['\"](.*)['\"]", txt).group(1)
     default = pyproject_name or resolve_path(".").name
-    name = default if with_defaults else logger.prompt("Project name", default=default)
+    name = logger.prompt("Project name", default=default) if interactive else default
     if snake_case:
         name = name.lower().replace(" ", "_").replace("-", "_")
     return name

--- a/src/siesta/utils/config.py
+++ b/src/siesta/utils/config.py
@@ -1,0 +1,44 @@
+# Copyright 2025 Entalpic
+import importlib
+
+# Package name for PyPI
+PACKAGE_NAME = "siesta"
+"""Name of the PyPI package for the ``siesta`` package."""
+
+PYPI_URL = f"https://pypi.org/pypi/{PACKAGE_NAME}/json"
+"""URL of the PyPI package for the ``siesta`` package."""
+
+GITHUB_OWNER = "entalpic"
+"""Name of the GitHub owner for the ``siesta`` repository."""
+GITHUB_REPO = "siesta"
+"""Name of the GitHub repository for the ``siesta`` package."""
+
+UPDATE_CHECK_ENV_VAR = "SIESTA_UPDATE_CHECK_HOURS"
+"""Name of the environment variable for update check frequency."""
+DEFAULT_UPDATE_CHECK_HOURS = 24
+"""Default update check frequency (in hours). Default is ``24`` (once per day).
+Set to ``"false"`` or ``"-1"`` to disable automatic checks.
+"""
+
+ROOT = importlib.resources.files(PACKAGE_NAME)
+"""Root directory of the ``siesta`` package."""
+
+CLI_DEFAULTS = {
+    "deps": True,
+    "as_main_deps": False,
+    "precommit": True,
+    "ipdb": True,
+    "tests": True,
+    "actions": True,
+    "gitignore": True,
+}
+"""Default values for the CLI when not in ``interactive`` mode.
+
+- ``deps``: Whether to install dependencies (dev &? docs), by default ``True``.
+- ``as_main_deps``: Whether to include docs dependencies in the main dependencies, by default ``False``.
+- ``precommit``: Whether to install pre-commit hooks, by default ``True``.
+- ``ipdb``: Whether to add ipdb as debugger, by default ``True``.
+- ``tests``: Whether to initialize (pytest) tests infra, by default ``True``.
+- ``actions``: Whether to initialize GitHub Actions, by default ``True``.
+- ``gitignore``: Whether to initialize the ``.gitignore`` file, by default ``True``.
+"""

--- a/src/siesta/utils/config.py
+++ b/src/siesta/utils/config.py
@@ -27,6 +27,7 @@ CLI_DEFAULTS = {
     "deps": True,
     "as_main_deps": False,
     "precommit": True,
+    "docs": True,
     "ipdb": True,
     "tests": True,
     "actions": True,
@@ -37,6 +38,7 @@ CLI_DEFAULTS = {
 - ``deps``: Whether to install dependencies (dev &? docs), by default ``True``.
 - ``as_main_deps``: Whether to include docs dependencies in the main dependencies, by default ``False``.
 - ``precommit``: Whether to install pre-commit hooks, by default ``True``.
+- ``docs``: Whether to initialize documentation (via ``siesta docs init``), by default ``True``.
 - ``ipdb``: Whether to add ipdb as debugger, by default ``True``.
 - ``tests``: Whether to initialize (pytest) tests infra, by default ``True``.
 - ``actions``: Whether to initialize GitHub Actions, by default ``True``.

--- a/src/siesta/utils/docs.py
+++ b/src/siesta/utils/docs.py
@@ -12,7 +12,6 @@ from tempfile import TemporaryDirectory
 from watchdog.events import FileSystemEvent, RegexMatchingEventHandler
 
 from siesta.utils.common import (
-    ROOT,
     get_project_name,
     get_pyver,
     load_deps,
@@ -21,6 +20,7 @@ from siesta.utils.common import (
     run_command,
     safe_dump,
 )
+from siesta.utils.config import ROOT
 from siesta.utils.github import fetch_github_files
 
 

--- a/src/siesta/utils/github.py
+++ b/src/siesta/utils/github.py
@@ -112,7 +112,7 @@ def fetch_github_files(
     pat = get_user_pat()
     if not pat:
         logger.abort(
-            "GitHub Personal Access Token (PAT) not found. Run 'siesta set-github-pat' to set it.",
+            "GitHub Personal Access Token (PAT) not found. Run 'siesta self set-github-pat' to set it.",
             exit=1,
         )
     auth = Token(pat)

--- a/src/siesta/utils/self.py
+++ b/src/siesta/utils/self.py
@@ -35,6 +35,14 @@ from packaging.version import Version
 from platformdirs import user_cache_dir
 
 from siesta.utils.common import logger, run_command
+from siesta.utils.config import (
+    DEFAULT_UPDATE_CHECK_HOURS,
+    GITHUB_OWNER,
+    GITHUB_REPO,
+    PACKAGE_NAME,
+    PYPI_URL,
+    UPDATE_CHECK_ENV_VAR,
+)
 from siesta.utils.github import get_user_pat
 
 if TYPE_CHECKING:
@@ -44,19 +52,6 @@ if TYPE_CHECKING:
         last_check: float
         latest_version: str | None
 
-
-# Package name for PyPI
-PACKAGE_NAME = "siesta"
-PYPI_URL = f"https://pypi.org/pypi/{PACKAGE_NAME}/json"
-
-# GitHub repo info
-GITHUB_OWNER = "entalpic"
-GITHUB_REPO = "siesta"
-
-# Environment variable for update check frequency (in hours)
-# Set to "false", "False", or "-1" to disable
-UPDATE_CHECK_ENV_VAR = "SIESTA_UPDATE_CHECK_HOURS"
-DEFAULT_UPDATE_CHECK_HOURS = 24
 
 # Cache file location (uses platform-appropriate directory)
 # - macOS: ~/Library/Caches/siesta

--- a/src/siesta/utils/tree.py
+++ b/src/siesta/utils/tree.py
@@ -183,7 +183,7 @@ def label_tree(
         The labeled tree lines.
     """
 
-    TREE_LABELS[f"src/{get_project_name(True, True)}/"] = (
+    TREE_LABELS[f"src/{get_project_name(interactive=False, snake_case=True)}/"] = (
         "Your (first?) package should live in here."
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,7 +85,7 @@ def module_test_path(tmp_path_factory):
     current_dir = Path.cwd()
     try:
         os.chdir(tmp_path)  # Change to temp directory
-        app(["project", "quickstart", "--with-defaults", "--local", "--overwrite"])
+        app(["project", "quickstart", "--local", "--overwrite"])
     finally:
         os.chdir(current_dir)  # Always restore original directory
     return tmp_path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,8 +38,8 @@ def capture_output():
         .. code-block:: python
 
             with capture_output() as output:
-                app(["show-deps"])
-            assert "numpy" in output.getvalue()
+                app(["self", "show-deps"])
+            assert "pytest" in output.getvalue()
 
         Returns
         -------

--- a/tests/test_cli/test_build_docs.py
+++ b/tests/test_cli/test_build_docs.py
@@ -27,7 +27,7 @@ def module_test_path_no_docs(tmp_path_factory):
     current_dir = Path.cwd()
     try:
         os.chdir(tmp_path)  # Change to temp directory
-        app(["project", "quickstart", "--with-defaults", "--local", "--overwrite"])
+        app(["project", "quickstart", "--local", "--overwrite"])
         shutil.rmtree(tmp_path / "docs")
     finally:
         os.chdir(current_dir)  # Always restore original directory

--- a/tests/test_cli/test_init_docs.py
+++ b/tests/test_cli/test_init_docs.py
@@ -10,7 +10,7 @@ def test_init_docs_basic(temp_project_with_git_and_remote, monkeypatch):
     monkeypatch.chdir(temp_project_with_git_and_remote)
 
     try:
-        app(["docs", "init", "--with-defaults", "--local"])
+        app(["docs", "init", "--local"])
     except SystemExit as e:
         assert e.code == 0
 
@@ -55,7 +55,7 @@ def test_init_docs_with_overwrite(
     (docs_dir / "marker.txt").write_text("original content")
 
     with capture_output() as output:
-        app(["docs", "init", "--overwrite", "--with-defaults", "--local"])
+        app(["docs", "init", "--overwrite", "--local"])
     assert "Failed to build the docs" not in output.getvalue()
 
     assert not (docs_dir / "marker.txt").exists()
@@ -69,7 +69,7 @@ def test_init_docs_package_discovery(
     monkeypatch.chdir(temp_project_with_git_and_remote)
 
     with capture_output() as output:
-        app(["docs", "init", "--with-defaults", "--local"])
+        app(["docs", "init", "--local"])
     assert "Failed to build the docs" not in output.getvalue()
 
     # Check conf.py contains discovered package
@@ -85,7 +85,7 @@ def test_init_docs_project_name(
     monkeypatch.chdir(temp_project_with_git_and_remote)
 
     with capture_output() as output:
-        app(["docs", "init", "--with-defaults", "--local"])
+        app(["docs", "init", "--local"])
     assert "Failed to build the docs" not in output.getvalue()
 
     # Check project name in conf.py
@@ -120,3 +120,22 @@ def test_init_docs_no_python_files(tmp_path, monkeypatch, capture_output):
         assert "No Python files found in project" in output.getvalue()
 
     assert exc_info.value.code == 1
+
+
+def test_init_docs_respects_no_deps(
+    temp_project_with_git_and_remote, monkeypatch, capture_output
+):
+    """Test that user flags take precedence (--no-deps)."""
+    monkeypatch.chdir(temp_project_with_git_and_remote)
+
+    with capture_output() as output:
+        # User specifies --no-deps, defaults should not override it
+        app(["docs", "init", "--no-deps", "--local"])
+
+    output_text = output.getvalue()
+    # deps should be False (user specified --no-deps)
+    assert "Skipping dependency installation" in output_text
+    # Docs should still be created
+    docs_dir = temp_project_with_git_and_remote / "docs"
+    assert docs_dir.exists()
+    assert (docs_dir / "source" / "conf.py").exists()

--- a/tests/test_cli/test_quickstart_project.py
+++ b/tests/test_cli/test_quickstart_project.py
@@ -8,7 +8,7 @@ def test_quickstart_project(tmp_path_chdir, capture_output):
     """Test project quickstart command creates expected project structure."""
 
     with capture_output() as output:
-        app(["project", "quickstart", "--with-defaults", "--local"])
+        app(["project", "quickstart", "--local"])
 
     assert "Failed to build the docs" not in output.getvalue()
 
@@ -31,7 +31,7 @@ def test_quickstart_project_as_app(tmp_path_chdir, capture_output):
     """Test project quickstart --as-app creates app structure instead of library."""
 
     with capture_output() as output:
-        app(["project", "quickstart", "--as-app", "--with-defaults", "--local"])
+        app(["project", "quickstart", "--as-app", "--local"])
 
     assert "Failed to build the docs" not in output.getvalue()
     # Should not have src directory for app
@@ -44,8 +44,78 @@ def test_quickstart_project_as_pkg(tmp_path_chdir, capture_output):
     """Test project quickstart --as-pkg creates package structure in root directory."""
 
     with capture_output() as output:
-        app(["project", "quickstart", "--as-pkg", "--with-defaults", "--local"])
+        app(["project", "quickstart", "--as-pkg", "--local"])
 
     assert "Failed to build the docs" not in output.getvalue()
     assert (tmp_path_chdir / "src").exists()
     assert (tmp_path_chdir / "src" / tmp_path_chdir.name).exists()
+
+
+def test_quickstart_respects_no_tests(tmp_path_chdir, capture_output):
+    """Test that user flags take precedence (--no-tests)."""
+
+    with capture_output() as output:
+        # User specifies --no-tests, defaults should not override it
+        app(["project", "quickstart", "--no-tests", "--local"])
+
+    output_text = output.getvalue()
+    assert "Failed to build the docs" not in output_text
+
+    # Check project structure - docs should exist (default)
+    assert Path(tmp_path_chdir, "docs").exists()
+    assert Path(tmp_path_chdir, "uv.lock").exists()
+
+    # Check tests directory does NOT exist (user specified --no-tests)
+    assert not Path(tmp_path_chdir, "tests").exists()
+
+    # GitHub Actions should STILL be created (actions is independent of tests)
+    assert Path(tmp_path_chdir, ".github").exists()
+    assert Path(tmp_path_chdir, ".github", "workflows", "test.yml").exists()
+
+    # User should be warned about having CI without tests
+    assert "GitHub Actions CI without tests" in output_text
+
+
+def test_quickstart_respects_no_actions(tmp_path_chdir, capture_output):
+    """Test that user flags take precedence (--no-actions)."""
+
+    with capture_output() as output:
+        # User specifies --no-actions, defaults should not override it
+        app(["project", "quickstart", "--no-actions", "--local"])
+
+    assert "Failed to build the docs" not in output.getvalue()
+
+    # Check project structure - tests should exist (default)
+    assert Path(tmp_path_chdir, "tests").exists()
+    assert Path(tmp_path_chdir, "docs").exists()
+
+    # Check GitHub Actions does NOT exist (user specified --no-actions)
+    assert not Path(tmp_path_chdir, ".github").exists()
+
+
+def test_quickstart_respects_no_tests_and_no_actions(tmp_path_chdir, capture_output):
+    """Test that user flags take precedence (both --no-tests and --no-actions)."""
+
+    with capture_output() as output:
+        # User specifies both --no-tests and --no-actions
+        app(
+            [
+                "project",
+                "quickstart",
+                "--no-tests",
+                "--no-actions",
+                "--local",
+            ]
+        )
+
+    assert "Failed to build the docs" not in output.getvalue()
+
+    # Check project structure - docs should exist (default)
+    assert Path(tmp_path_chdir, "docs").exists()
+    assert Path(tmp_path_chdir, "uv.lock").exists()
+
+    # Check tests directory does NOT exist (user specified --no-tests)
+    assert not Path(tmp_path_chdir, "tests").exists()
+
+    # Check GitHub Actions does NOT exist (user specified --no-actions)
+    assert not Path(tmp_path_chdir, ".github").exists()

--- a/tests/test_cli/test_setup_tests.py
+++ b/tests/test_cli/test_setup_tests.py
@@ -28,7 +28,7 @@ def existing_uv_project(tmp_path):
 def test_setup_tests_creates_tests_directory(existing_uv_project, capture_output):
     """Test that setup-tests creates the tests directory with example test."""
     with capture_output() as output:
-        app(["project", "setup-tests", "--with-defaults"])
+        app(["project", "setup-tests"])
 
     output_text = output.getvalue()
     assert "Tests infra written" in output_text
@@ -48,7 +48,7 @@ def test_setup_tests_creates_tests_directory(existing_uv_project, capture_output
 def test_setup_tests_creates_github_actions(existing_uv_project, capture_output):
     """Test that setup-tests creates GitHub Actions workflow."""
     with capture_output():
-        app(["project", "setup-tests", "--with-defaults"])
+        app(["project", "setup-tests"])
 
     # Check GitHub Actions directory exists
     assert (existing_uv_project / ".github").exists()
@@ -60,7 +60,7 @@ def test_setup_tests_without_actions(existing_uv_project, capture_output):
     """Test that setup-tests can skip GitHub Actions setup."""
     with capture_output() as output:
         # Use --deps to install deps but --no-actions to skip actions
-        # Pass project name and --no-with-defaults to avoid prompts
+        # Pass project name and -i (interactive) to test explicit flag handling
         app(
             [
                 "project",
@@ -68,7 +68,7 @@ def test_setup_tests_without_actions(existing_uv_project, capture_output):
                 "--project-name=existing_project",
                 "--deps",
                 "--no-actions",
-                "--no-with-defaults",
+                "-i",
             ]
         )
 
@@ -91,7 +91,7 @@ def test_setup_tests_skips_existing_tests_directory(
     (existing_uv_project / "tests" / "existing_test.py").write_text("# existing test")
 
     with capture_output() as output:
-        app(["project", "setup-tests", "--with-defaults"])
+        app(["project", "setup-tests"])
 
     output_text = output.getvalue()
     assert "Tests directory already exists" in output_text
@@ -100,3 +100,68 @@ def test_setup_tests_skips_existing_tests_directory(
     assert (existing_uv_project / "tests" / "existing_test.py").exists()
     # Check no new test file was created
     assert not (existing_uv_project / "tests" / "test_import.py").exists()
+
+
+def test_setup_tests_respects_no_actions(existing_uv_project, capture_output):
+    """Test that user flags take precedence (--no-actions)."""
+    with capture_output() as output:
+        # User specifies --no-actions, defaults should not override it
+        app(["project", "setup-tests", "--no-actions"])
+
+    output_text = output.getvalue()
+    assert "Tests infra written" in output_text
+    # deps should default to True
+    assert "Test dependencies installed" in output_text
+
+    # Check tests directory exists (deps=True by default)
+    assert (existing_uv_project / "tests").exists()
+
+    # Check GitHub Actions was NOT created (user specified --no-actions)
+    assert not (existing_uv_project / ".github").exists()
+
+
+def test_setup_tests_respects_no_deps(existing_uv_project, capture_output):
+    """Test that user flags take precedence (--no-deps)."""
+    with capture_output() as output:
+        # User specifies --no-deps, defaults should not override it
+        app(["project", "setup-tests", "--no-deps"])
+
+    output_text = output.getvalue()
+    assert "Tests infra written" in output_text
+    # deps should be False (user specified --no-deps)
+    assert "Test dependencies installed" not in output_text
+    # actions should default to True
+    assert "Test actions config written" in output_text
+
+    # Check tests directory exists
+    assert (existing_uv_project / "tests").exists()
+
+    # Check GitHub Actions WAS created (actions=True by default)
+    assert (existing_uv_project / ".github" / "workflows" / "test.yml").exists()
+
+
+def test_setup_tests_interactive_flag(existing_uv_project, capture_output):
+    """Test that -i/--interactive enables prompts instead of using defaults."""
+    with capture_output() as output:
+        # Use -i with explicit flags to avoid prompts in test
+        # -i should override default behavior (which would auto-accept)
+        app(
+            [
+                "project",
+                "setup-tests",
+                "-i",  # interactive mode
+                "--project-name=existing_project",  # explicitly set to avoid prompt
+                "--deps",  # explicitly set to avoid prompt
+                "--no-actions",  # explicitly set to avoid prompt
+            ]
+        )
+
+    output_text = output.getvalue()
+    assert "Tests infra written" in output_text
+    assert "Test dependencies installed" in output_text
+
+    # Check tests directory exists
+    assert (existing_uv_project / "tests").exists()
+
+    # Check GitHub Actions was NOT created (we specified --no-actions)
+    assert not (existing_uv_project / ".github").exists()

--- a/tests/test_cli/test_setup_tests.py
+++ b/tests/test_cli/test_setup_tests.py
@@ -1,0 +1,102 @@
+# Copyright 2025 Entalpic
+import os
+from pathlib import Path
+from subprocess import run
+
+import pytest
+
+from siesta.cli import app
+
+
+@pytest.fixture
+def existing_uv_project(tmp_path):
+    """Create a temporary directory with an existing uv project."""
+    current_dir = Path.cwd()
+    test_path = tmp_path / "existing_project"
+    test_path.mkdir(parents=True, exist_ok=True)
+    os.chdir(test_path)
+
+    # Initialize a basic uv project and create uv.lock
+    run(["uv", "init", "--lib", "--name=existing_project"], check=True)
+    # Run uv sync to create the uv.lock file
+    run(["uv", "sync"], check=True)
+
+    yield test_path
+    os.chdir(current_dir)
+
+
+def test_setup_tests_creates_tests_directory(existing_uv_project, capture_output):
+    """Test that setup-tests creates the tests directory with example test."""
+    with capture_output() as output:
+        app(["project", "setup-tests", "--with-defaults"])
+
+    output_text = output.getvalue()
+    assert "Tests infra written" in output_text
+    assert "Test actions config written" in output_text
+    assert "Testing infrastructure set up successfully" in output_text
+
+    # Check tests directory exists
+    assert (existing_uv_project / "tests").exists()
+    assert (existing_uv_project / "tests" / "test_import.py").exists()
+
+    # Check test file content
+    test_content = (existing_uv_project / "tests" / "test_import.py").read_text()
+    assert "import existing_project" in test_content
+    assert "def test_import" in test_content
+
+
+def test_setup_tests_creates_github_actions(existing_uv_project, capture_output):
+    """Test that setup-tests creates GitHub Actions workflow."""
+    with capture_output():
+        app(["project", "setup-tests", "--with-defaults"])
+
+    # Check GitHub Actions directory exists
+    assert (existing_uv_project / ".github").exists()
+    assert (existing_uv_project / ".github" / "workflows").exists()
+    assert (existing_uv_project / ".github" / "workflows" / "test.yml").exists()
+
+
+def test_setup_tests_without_actions(existing_uv_project, capture_output):
+    """Test that setup-tests can skip GitHub Actions setup."""
+    with capture_output() as output:
+        # Use --deps to install deps but --no-actions to skip actions
+        # Pass project name and --no-with-defaults to avoid prompts
+        app(
+            [
+                "project",
+                "setup-tests",
+                "--project-name=existing_project",
+                "--deps",
+                "--no-actions",
+                "--no-with-defaults",
+            ]
+        )
+
+    output_text = output.getvalue()
+    assert "Tests infra written" in output_text
+
+    # Check tests directory exists
+    assert (existing_uv_project / "tests").exists()
+
+    # Check GitHub Actions was NOT created
+    assert not (existing_uv_project / ".github").exists()
+
+
+def test_setup_tests_skips_existing_tests_directory(
+    existing_uv_project, capture_output
+):
+    """Test that setup-tests warns and skips if tests directory already exists."""
+    # Create tests directory first
+    (existing_uv_project / "tests").mkdir()
+    (existing_uv_project / "tests" / "existing_test.py").write_text("# existing test")
+
+    with capture_output() as output:
+        app(["project", "setup-tests", "--with-defaults"])
+
+    output_text = output.getvalue()
+    assert "Tests directory already exists" in output_text
+
+    # Check existing test file is preserved
+    assert (existing_uv_project / "tests" / "existing_test.py").exists()
+    # Check no new test file was created
+    assert not (existing_uv_project / "tests" / "test_import.py").exists()

--- a/tests/test_cli/test_show_deps.py
+++ b/tests/test_cli/test_show_deps.py
@@ -4,10 +4,10 @@ from siesta.utils.common import load_deps
 
 
 def test_show_deps(capture_output):
-    """Test the show-deps command outputs the expected dependencies."""
+    """Test the self show-deps command outputs the expected dependencies."""
     with capture_output() as output:
         try:
-            app(["show-deps"])
+            app(["self", "show-deps"])
         except SystemExit as e:
             assert e.code == 0
 


### PR DESCRIPTION
## Standalone Test Setup & CLI Improvements

**TL;DR:** Adds `siesta project setup-tests` command for standalone test infrastructure, replaces `--with-defaults` with `--interactive` flag, and reorganizes CLI commands under `siesta self`.

cf #30 too

---

### Changes

**New Feature: `siesta project setup-tests`**
- Standalone command to add pytest infrastructure to existing projects
- Installs `pytest` and `pytest-cov` as dev deps
- Creates `tests/` directory with example test file
- Optionally sets up GitHub Actions CI

**CLI UX Improvements**
- Replaced `--with-defaults` with `-i/--interactive` (inverted logic)
  - Non-interactive by default with sensible defaults
  - User-specified flags always take precedence
  - Use `-i` to be prompted for each option
- Moved `set-github-pat` and `show-deps` under `siesta self` subcommand
  - `siesta set-github-pat` → `siesta self set-github-pat`
  - `siesta show-deps` → `siesta self show-deps`

**Refactoring**
- Centralized CLI defaults in new `config.py` module
- `quickstart` now delegates to `setup-tests` for test infrastructure

**Bug Fix**
- Fixed missing `docs` key in default config

---

### Files Changed
- 16 files, +584 / -150 lines
- New: `src/siesta/utils/config.py`, `tests/test_cli/test_setup_tests.py`
