### PR TITLE
Refactor: --local first and make remote an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Use `siesta` to initialize
 1. Start a new Python project from scratch
 
     ```bash
-    siesta project quickstart --local
+    siesta project quickstart
     ```
 
 2. Add testing infrastructure (pytest) to an _existing_ project
@@ -23,7 +23,7 @@ Use `siesta` to initialize
 3. Add documentation to an _existing_ project
 
     ```bash
-    siesta docs init --local
+    siesta docs init
     ```
 
 4. Build the docs locally

--- a/docs/source/_templates/autoapi/index.rst
+++ b/docs/source/_templates/autoapi/index.rst
@@ -25,9 +25,9 @@ TL;DR
 .. code-block:: bash
 
    # 1️⃣ Start new project
-   $ siesta project quickstart --local
+   $ siesta project quickstart
    # 1️⃣ Initialize docs in existing project
-   $ siesta docs init --local
+   $ siesta docs init
 
    # 2️⃣ Build docs
    $ siesta docs build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,8 @@ dependencies = [
 [project.scripts]
 siesta = "siesta.cli:main"
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "ipdb>=0.13.13",
     "ipython>=8.28.0",
     "matplotlib>=3.10.6",

--- a/src/siesta/__init__.py
+++ b/src/siesta/__init__.py
@@ -24,12 +24,12 @@ TL;DR
 
 .. code-block:: bash
 
-    # With local files (no GitHub PAT needed)
-    $ siesta project quickstart --local
+    # Uses local bundled files (no GitHub PAT needed)
+    $ siesta project quickstart
 
     # With most up to date remote files (requires GitHub PAT)
     $ siesta self set-github-pat
-    $ siesta project quickstart
+    $ siesta project quickstart --remote-assets
 
 **Add documentation to an existing project:**
 
@@ -97,15 +97,18 @@ the ``docs`` command with the ``init`` subcommand.
     $ siesta docs init --help
     $ siesta docs init --with-defaults
 
-This creates a ``docs/`` folder in your project and installing the necessary
-dependencies. Some of the contents of the ``docs/`` folder are copied from the Entalpic
-Github repository and therefore requires you to set a Github Personal Access Token (PAT)
-to access the files.
+This creates a ``docs/`` folder in your project and installs the necessary
+dependencies. By default, the bundled local boilerplate files are used. To fetch the
+most up-to-date files from the Entalpic Github repository, use the ``--remote-assets``
+flag (requires a Github Personal Access Token).
 
 .. code-block:: bash
 
-    $ siesta self set-github-pat
     $ siesta docs init --uv --with-defaults
+
+    # Or, to fetch the latest remote files:
+    $ siesta self set-github-pat
+    $ siesta docs init --uv --with-defaults --remote-assets
 
 Going further
 =============
@@ -151,10 +154,10 @@ Currently ``siesta`` has 3 main subcommands:
 
 .. note::
 
-    ``docs init`` and ``docs update`` require a Github Personal Access Token (PAT) to
-    access remote files. You can set it with ``$ siesta self set-github-pat``. Alternatively,
-    you can use the ``--local`` flag to use local files instead of fetching from Github.
-    Note that it may therefore not use the most up-to-date files to render the docs.
+    By default, ``docs init`` and ``docs update`` use locally bundled boilerplate files
+    and do not require a Github Personal Access Token (PAT). Use ``--remote-assets`` to
+    fetch the latest files from Github (requires a PAT, set it with
+    ``$ siesta self set-github-pat``).
 
 When running ``$ siesta docs init`` the following happens:
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,7 +85,7 @@ def module_test_path(tmp_path_factory):
     current_dir = Path.cwd()
     try:
         os.chdir(tmp_path)  # Change to temp directory
-        app(["project", "quickstart", "--local", "--overwrite"])
+        app(["project", "quickstart", "--overwrite"])
     finally:
         os.chdir(current_dir)  # Always restore original directory
     return tmp_path

--- a/tests/test_cli/test_build_docs.py
+++ b/tests/test_cli/test_build_docs.py
@@ -27,7 +27,7 @@ def module_test_path_no_docs(tmp_path_factory):
     current_dir = Path.cwd()
     try:
         os.chdir(tmp_path)  # Change to temp directory
-        app(["project", "quickstart", "--local", "--overwrite"])
+        app(["project", "quickstart", "--overwrite"])
         shutil.rmtree(tmp_path / "docs")
     finally:
         os.chdir(current_dir)  # Always restore original directory

--- a/tests/test_cli/test_init_docs.py
+++ b/tests/test_cli/test_init_docs.py
@@ -10,7 +10,7 @@ def test_init_docs_basic(temp_project_with_git_and_remote, monkeypatch):
     monkeypatch.chdir(temp_project_with_git_and_remote)
 
     try:
-        app(["docs", "init", "--local"])
+        app(["docs", "init"])
     except SystemExit as e:
         assert e.code == 0
 
@@ -37,7 +37,7 @@ def test_init_docs_no_overwrite(
 
     with pytest.raises(SystemExit) as exc_info:
         with capture_output() as output:
-            app(["docs", "init", "--local"])
+            app(["docs", "init"])
         assert "Path already exists" in output.getvalue()
 
     assert exc_info.value.code == 1
@@ -55,7 +55,7 @@ def test_init_docs_with_overwrite(
     (docs_dir / "marker.txt").write_text("original content")
 
     with capture_output() as output:
-        app(["docs", "init", "--overwrite", "--local"])
+        app(["docs", "init", "--overwrite"])
     assert "Failed to build the docs" not in output.getvalue()
 
     assert not (docs_dir / "marker.txt").exists()
@@ -69,7 +69,7 @@ def test_init_docs_package_discovery(
     monkeypatch.chdir(temp_project_with_git_and_remote)
 
     with capture_output() as output:
-        app(["docs", "init", "--local"])
+        app(["docs", "init"])
     assert "Failed to build the docs" not in output.getvalue()
 
     # Check conf.py contains discovered package
@@ -85,7 +85,7 @@ def test_init_docs_project_name(
     monkeypatch.chdir(temp_project_with_git_and_remote)
 
     with capture_output() as output:
-        app(["docs", "init", "--local"])
+        app(["docs", "init"])
     assert "Failed to build the docs" not in output.getvalue()
 
     # Check project name in conf.py
@@ -116,7 +116,7 @@ def test_init_docs_no_python_files(tmp_path, monkeypatch, capture_output):
 
     with pytest.raises(SystemExit) as exc_info:
         with capture_output() as output:
-            app(["docs", "init", "--local"])
+            app(["docs", "init"])
         assert "No Python files found in project" in output.getvalue()
 
     assert exc_info.value.code == 1
@@ -130,7 +130,7 @@ def test_init_docs_respects_no_deps(
 
     with capture_output() as output:
         # User specifies --no-deps, defaults should not override it
-        app(["docs", "init", "--no-deps", "--local"])
+        app(["docs", "init", "--no-deps"])
 
     output_text = output.getvalue()
     # deps should be False (user specified --no-deps)

--- a/tests/test_cli/test_quickstart_project.py
+++ b/tests/test_cli/test_quickstart_project.py
@@ -8,7 +8,7 @@ def test_quickstart_project(tmp_path_chdir, capture_output):
     """Test project quickstart command creates expected project structure."""
 
     with capture_output() as output:
-        app(["project", "quickstart", "--local"])
+        app(["project", "quickstart"])
 
     assert "Failed to build the docs" not in output.getvalue()
 
@@ -31,7 +31,7 @@ def test_quickstart_project_as_app(tmp_path_chdir, capture_output):
     """Test project quickstart --as-app creates app structure instead of library."""
 
     with capture_output() as output:
-        app(["project", "quickstart", "--as-app", "--local"])
+        app(["project", "quickstart", "--as-app"])
 
     assert "Failed to build the docs" not in output.getvalue()
     # Should not have src directory for app
@@ -44,7 +44,7 @@ def test_quickstart_project_as_pkg(tmp_path_chdir, capture_output):
     """Test project quickstart --as-pkg creates package structure in root directory."""
 
     with capture_output() as output:
-        app(["project", "quickstart", "--as-pkg", "--local"])
+        app(["project", "quickstart", "--as-pkg"])
 
     assert "Failed to build the docs" not in output.getvalue()
     assert (tmp_path_chdir / "src").exists()
@@ -56,7 +56,7 @@ def test_quickstart_respects_no_tests(tmp_path_chdir, capture_output):
 
     with capture_output() as output:
         # User specifies --no-tests, defaults should not override it
-        app(["project", "quickstart", "--no-tests", "--local"])
+        app(["project", "quickstart", "--no-tests"])
 
     output_text = output.getvalue()
     assert "Failed to build the docs" not in output_text
@@ -81,7 +81,7 @@ def test_quickstart_respects_no_actions(tmp_path_chdir, capture_output):
 
     with capture_output() as output:
         # User specifies --no-actions, defaults should not override it
-        app(["project", "quickstart", "--no-actions", "--local"])
+        app(["project", "quickstart", "--no-actions"])
 
     assert "Failed to build the docs" not in output.getvalue()
 
@@ -104,7 +104,6 @@ def test_quickstart_respects_no_tests_and_no_actions(tmp_path_chdir, capture_out
                 "quickstart",
                 "--no-tests",
                 "--no-actions",
-                "--local",
             ]
         )
 


### PR DESCRIPTION
## TL;DR

Make local bundled boilerplate the default for all commands by replacing the `--local` flag with an opt-in `--remote-assets` flag, and modernize `pyproject.toml` to use `[dependency-groups]`.

## Breaking changes 🔥

- **🟠 CLI flag renamed**: `--local` is removed from `docs init`, `docs update`, and `project quickstart`. Local is now the default. Users who relied on `--local` in scripts will get an unknown-flag error. Replace `--local` with nothing (it's the default) or use `--remote-assets` to fetch from GitHub.

## Changes

- **Local-first boilerplate**: Invert the default so `docs init`, `docs update`, and `project quickstart` use locally bundled files without requiring a GitHub PAT. 
- **Add `--remote-assets` flag** for users who want the latest remote files.
- **`pyproject.toml` modernized**: Replace deprecated `[tool.uv] dev-dependencies` with `[dependency-groups] dev`, fixing the `uv sync` deprecation warning.
- **Bugfix — missing `CLI_DEFAULTS["docs"]`**: Add the `"docs": True` entry to `CLI_DEFAULTS` to fix a `KeyError` crash in `quickstart_project` non-interactive mode.

## Review hints

- The core logic change is in `cli.py:init_docs` around lines 318-330 — the PAT check is now conditional on `remote_assets`. Verify nothing else depended on `pat` being set unconditionally.
- `utils/docs.py:update_conf_py` now has two code paths (local vs remote) — confirm the local path correctly copies from the bundled boilerplate.
