### PR TITLE
feat: add self show-github-pat

### DIFF
--- a/src/siesta/cli.py
+++ b/src/siesta/cli.py
@@ -27,6 +27,7 @@ Learn how to use with:
     $ siesta self version
     $ siesta self update  # or: siesta self upgrade
     $ siesta self set-github-pat
+    $ siesta self show-github-pat
     $ siesta self show-deps
 
 You can also refer to the :ref:`siesta-cli-tutorial` for more information.
@@ -221,6 +222,36 @@ def set_github_pat(pat: Optional[str] = ""):
     logger.success(
         "GitHub PAT set. You can now use ``--remote-assets`` to fetch remote files."
     )
+
+
+@self_app.command(name="show-github-pat")
+def show_github_pat(full: bool = False):
+    """
+    Display the stored GitHub Personal Access Token (PAT).
+
+    By default, shows a masked version of the token (first 14 and last 4 characters)
+    for identification without exposing the full secret.
+
+    Parameters
+    ----------
+    full : bool, optional
+        Show the full token in plaintext instead of the masked version.
+    """
+    pat = get_user_pat()
+    if not pat:
+        logger.warning(
+            "No GitHub PAT found."
+            + " Run [r]$ siesta self set-github-pat[/r] to set one."
+        )
+        return
+
+    if full:
+        logger.warning("The full token will be displayed in plaintext.")
+        logger.info(f"GitHub PAT: {pat}")
+    else:
+        masked = f"{pat[:14]}...{pat[-4:]}"
+        logger.info(f"GitHub PAT: {masked}")
+        logger.info("Use [r]--full[/r] to display the entire token.")
 
 
 @self_app.command(name="show-deps")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,8 +20,12 @@ def mock_user_pat():
 
     This fixture is automatically used in all tests.
     """
-    with patch(
-        "siesta.utils.github.get_user_pat", return_value="fake-github-pat-for-testing"
+    with (
+        patch(
+            "siesta.utils.github.get_user_pat",
+            return_value="fake-github-pat-for-testing",
+        ),
+        patch("siesta.cli.get_user_pat", return_value="fake-github-pat-for-testing"),
     ):
         yield
 

--- a/tests/test_cli/test_show_github_pat.py
+++ b/tests/test_cli/test_show_github_pat.py
@@ -1,0 +1,37 @@
+# Copyright 2025 Entalpic
+from unittest.mock import patch
+
+from siesta.cli import app
+
+
+def test_show_github_pat_masked(capture_output):
+    """Test that show-github-pat displays a masked token by default."""
+    with capture_output() as output:
+        app(["self", "show-github-pat"])
+
+    output_text = output.getvalue()
+    assert "fake-github-" in output_text
+    assert "ting" in output_text
+    assert "fake-github-pat-for-testing" not in output_text
+    assert "--full" in output_text
+
+
+def test_show_github_pat_full(capture_output):
+    """Test that show-github-pat --full displays the full token with a warning."""
+    with capture_output() as output:
+        app(["self", "show-github-pat", "--full"])
+
+    output_text = output.getvalue()
+    assert "fake-github-pat-for-testing" in output_text
+    assert "plaintext" in output_text
+
+
+def test_show_github_pat_none(capture_output):
+    """Test that show-github-pat warns when no PAT is stored."""
+    with patch("siesta.utils.github.get_user_pat", return_value=None):
+        with capture_output() as output:
+            app(["self", "show-github-pat"])
+
+    output_text = output.getvalue()
+    assert "No GitHub PAT found" in output_text
+    assert "set-github-pat" in output_text

--- a/tests/test_cli/test_show_github_pat.py
+++ b/tests/test_cli/test_show_github_pat.py
@@ -28,7 +28,10 @@ def test_show_github_pat_full(capture_output):
 
 def test_show_github_pat_none(capture_output):
     """Test that show-github-pat warns when no PAT is stored."""
-    with patch("siesta.utils.github.get_user_pat", return_value=None):
+    with (
+        patch("siesta.utils.github.get_user_pat", return_value=None),
+        patch("siesta.cli.get_user_pat", return_value=None),
+    ):
         with capture_output() as output:
             app(["self", "show-github-pat"])
 


### PR DESCRIPTION
Add an option to show the Github PAT

```
❯ siesta self show-github-pat
[siesta | 19:01:55] GitHub PAT: github_pat_11A...9uqg
[siesta | 19:01:55] Use --full to display the entire token.
```

```
❯ siesta self show-github-pat --full
[siesta | 19:02:11] The full token will be displayed in plaintext.
[siesta | 19:02:11] GitHub PAT:
github_pat_11ACG2PEz[...]z2DLa9uqg
```