### PR TITLE
Enhance `siesta self version` to show GitHub release and latest main commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Custom
 .vscode/
 .DS_Store
+.todo
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/src/siesta/cli.py
+++ b/src/siesta/cli.py
@@ -84,6 +84,8 @@ from siesta.utils.project import (
 from siesta.utils.self import (
     compare_versions,
     get_installation_method,
+    get_latest_commit_info,
+    get_latest_github_release_version,
     get_latest_version,
     get_update_command,
     get_update_message,
@@ -1007,40 +1009,43 @@ def tree_project(path: str = ".", ignore_from_gitignore: bool = True):
 def self_version():
     """Show the current siesta version and check for updates.
 
-    Displays the installed version, installation method, and whether
-    a newer version is available on PyPI.
+    Displays the installed pip version, latest GitHub release,
+    and latest commit on main.
     """
     from siesta import __version__
 
-    # Get installation method
-    method = get_installation_method()
-    method_display = {
-        "uv": "uv tool",
-        "pipx": "pipx",
-        "pip": "pip",
-        "editable": "editable (development)",
-    }.get(method, method)
+    logger.info(f"Installed (pip): [r]{__version__}[/r]")
 
-    logger.info(f"siesta version: [r]{__version__}[/r]")
-    logger.info(f"Installation method: [r]{method_display}[/r]")
+    with logger.loading("Fetching latest versions from GitHub..."):
+        release_version, release_err = get_latest_github_release_version()
+        commit_info, commit_err = get_latest_commit_info()
 
-    # Check for updates
-    with logger.loading("Checking for updates..."):
-        latest = get_latest_version()
-
-    if latest is None:
-        logger.warning("Could not check for updates (network error).")
-        return
-
-    comparison = compare_versions(__version__, latest)
-    if comparison < 0:
-        logger.warning(f"A newer version is available: [r]{latest}[/r]")
-        logger.info("Run [r]siesta self update[/r] to upgrade.")
-    elif comparison > 0:
-        logger.info("You are running a pre-release or development version.")
-        logger.info(f"Latest stable release: [r]{latest}[/r]")
+    if release_version is not None:
+        logger.info(f"GitHub release:  [r]{release_version}[/r]")
     else:
-        logger.success("You are running the latest version.")
+        _detail = f" ({release_err})" if release_err else ""
+        logger.warning(f"GitHub release:  could not fetch{_detail}")
+
+    if commit_info is not None:
+        time_str = commit_info["time"].strftime("%Y-%m-%d %H:%M:%S UTC")
+        logger.info(
+            f"GitHub main:     [r]{commit_info['hash']}[/r]"
+            f" by {commit_info['author']}"
+            f" ({time_str})"
+        )
+    else:
+        _detail = f" ({commit_err})" if commit_err else ""
+        logger.warning(f"GitHub main:     could not fetch{_detail}")
+
+    if release_version is not None:
+        comparison = compare_versions(__version__, release_version)
+        if comparison < 0:
+            logger.warning(f"A newer version is available: [r]{release_version}[/r]")
+            logger.info("Run [r]siesta self update[/r] to upgrade.")
+        elif comparison > 0:
+            logger.info("You are running a pre-release or development version.")
+        else:
+            logger.success("You are running the latest release.")
 
 
 @self_app.command(name="update")
@@ -1082,10 +1087,11 @@ def self_update(force: bool = False, dry: bool = False):
 
     # Check current vs latest version
     with logger.loading("Checking for updates..."):
-        latest = get_latest_version()
+        latest, check_err = get_latest_version()
 
     if latest is None:
-        logger.warning("Could not check for latest version (network error).")
+        _detail = f" ({check_err})" if check_err else ""
+        logger.warning(f"Could not check for latest version{_detail}.")
         if not force:
             logger.info("Use [r]--force[/r] to update anyway.")
             return

--- a/src/siesta/cli.py
+++ b/src/siesta/cli.py
@@ -74,7 +74,11 @@ from siesta.utils.docs import (
     update_conf_py,
     write_rtd_config,
 )
-from siesta.utils.github import get_user_pat
+from siesta.utils.github import (
+    get_latest_commit_info,
+    get_latest_github_release_version,
+    get_user_pat,
+)
 from siesta.utils.project import (
     add_ipdb_as_debugger,
     write_gitignore,
@@ -84,8 +88,6 @@ from siesta.utils.project import (
 from siesta.utils.self import (
     compare_versions,
     get_installation_method,
-    get_latest_commit_info,
-    get_latest_github_release_version,
     get_latest_version,
     get_update_command,
     get_update_message,

--- a/src/siesta/utils/github.py
+++ b/src/siesta/utils/github.py
@@ -204,8 +204,7 @@ def _get_github_client(timeout: float = 5.0) -> Github:
 def _get_latest_version_github(timeout: float = 5.0) -> tuple[str | None, str | None]:
     """Query GitHub for the latest siesta version.
 
-    First tries without authentication (public repo), then falls back to
-    PAT authentication if rate-limited or if access is denied.
+    Uses a PAT if one is configured, otherwise makes an unauthenticated request.
 
     Parameters
     ----------
@@ -219,62 +218,30 @@ def _get_latest_version_github(timeout: float = 5.0) -> tuple[str | None, str | 
         ``(version, None)`` on success, ``(None, None)`` if no release/tag was found,
         or ``(None, err)`` on failure.
     """
-
-    def try_get_version(g: Github) -> str | None:
-        """Try to get version from releases, then tags."""
+    try:
+        g = _get_github_client(timeout=timeout)
         repo = g.get_repo(f"{GITHUB_OWNER}/{GITHUB_REPO}")
 
         # Try releases first
         try:
             release = repo.get_latest_release()
             tag_name = release.tag_name
-            return tag_name.lstrip("v") if tag_name else None
+            return (tag_name.lstrip("v"), None) if tag_name else (None, None)
         except GithubException as e:
-            # 404 means no releases, try tags
-            if e.status == 404:
-                pass
-            else:
+            # 404 means no releases, fall back to tags
+            if e.status != 404:
                 raise
 
         # Fall back to tags
         tags = repo.get_tags()
         if tags.totalCount > 0:
             tag_name = tags[0].name
-            return tag_name.lstrip("v") if tag_name else None
+            return (tag_name.lstrip("v"), None) if tag_name else (None, None)
 
-        return None
-
-    unauth_forbidden: GithubException | None = None
-
-    # Try unauthenticated first (public repo)
-    try:
-        g = Github(timeout=int(timeout))
-        result = try_get_version(g)
-        if result:
-            return (result, None)
+        return (None, None)
     except GithubException as e:
-        # 403 often means rate limited, will try with auth
-        if e.status == 403:
-            unauth_forbidden = e
-        else:
-            logger.warning(f"Failed to fetch latest version from GitHub: {e}")
-            return (None, format_github_access_error(e))
-
-    # Fall back to PAT authentication (for rate limiting)
-    pat = get_user_pat()
-    if pat:
-        try:
-            g = Github(auth=Token(pat), timeout=int(timeout))
-            result = try_get_version(g)
-            if result:
-                return (result, None)
-        except GithubException as e:
-            logger.warning(f"Failed to fetch latest version from GitHub: {e}")
-            return (None, format_github_access_error(e))
-    elif unauth_forbidden is not None:
-        return (None, format_github_access_error(unauth_forbidden))
-
-    return (None, None)
+        logger.warning(f"Failed to fetch latest version from GitHub: {e}")
+        return (None, format_github_access_error(e))
 
 
 def get_latest_github_release_version(

--- a/src/siesta/utils/github.py
+++ b/src/siesta/utils/github.py
@@ -222,29 +222,25 @@ def _get_latest_version_github(timeout: float = 5.0) -> tuple[str | None, str | 
 
     def try_get_version(g: Github) -> str | None:
         """Try to get version from releases, then tags."""
+        repo = g.get_repo(f"{GITHUB_OWNER}/{GITHUB_REPO}")
+
+        # Try releases first
         try:
-            repo = g.get_repo(f"{GITHUB_OWNER}/{GITHUB_REPO}")
+            release = repo.get_latest_release()
+            tag_name = release.tag_name
+            return tag_name.lstrip("v") if tag_name else None
+        except GithubException as e:
+            # 404 means no releases, try tags
+            if e.status == 404:
+                pass
+            else:
+                raise
 
-            # Try releases first
-            try:
-                release = repo.get_latest_release()
-                tag_name = release.tag_name
-                return tag_name.lstrip("v") if tag_name else None
-            except GithubException as e:
-                # 404 means no releases, try tags
-                if e.status == 404:
-                    pass
-                else:
-                    raise
-
-            # Fall back to tags
-            tags = repo.get_tags()
-            if tags.totalCount > 0:
-                tag_name = tags[0].name
-                return tag_name.lstrip("v") if tag_name else None
-
-        except GithubException:
-            raise
+        # Fall back to tags
+        tags = repo.get_tags()
+        if tags.totalCount > 0:
+            tag_name = tags[0].name
+            return tag_name.lstrip("v") if tag_name else None
 
         return None
 

--- a/src/siesta/utils/github.py
+++ b/src/siesta/utils/github.py
@@ -1,15 +1,32 @@
 # Copyright 2025 Entalpic
 """Utility functions related to GitHub."""
 
-import re
-from pathlib import Path
+from __future__ import annotations
 
-from github import Github, UnknownObjectException
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import TypedDict
+
+from github import (
+    BadCredentialsException,
+    Github,
+    GithubException,
+    RateLimitExceededException,
+    UnknownObjectException,
+)
 from github.Auth import Token
 from github.Repository import Repository
 from keyring import get_password
 
 from siesta.utils.common import logger, resolve_path
+from siesta.utils.config import GITHUB_OWNER, GITHUB_REPO
+
+
+class CommitInfo(TypedDict):
+    hash: str
+    author: str
+    time: datetime
 
 
 def get_user_pat():
@@ -136,3 +153,187 @@ def fetch_github_files(
         path = Path(base_dir) / name
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_bytes(content)
+
+
+def format_github_access_error(exc: BaseException) -> str:
+    """Summarize a PyGithub or transport error for user-facing messages.
+
+    Parameters
+    ----------
+    exc : BaseException
+        The exception raised when calling the GitHub API.
+
+    Returns
+    -------
+    str
+        A short, human-readable description.
+    """
+    if isinstance(exc, BadCredentialsException):
+        return (
+            "GitHub rejected the token (invalid or expired). "
+            "Run `siesta self set-github-pat` with a valid PAT."
+        )
+    if isinstance(exc, RateLimitExceededException):
+        return "GitHub API rate limit exceeded. Try again later or set a PAT."
+    if isinstance(exc, GithubException):
+        data = exc.data if isinstance(exc.data, dict) else {}
+        msg = data.get("message") or str(exc)
+        return f"GitHub API {exc.status}: {msg}"
+    return str(exc) or type(exc).__name__
+
+
+def _get_github_client(timeout: float = 5.0) -> Github:
+    """Get a GitHub client, trying unauthenticated first then falling back to PAT.
+
+    Parameters
+    ----------
+    timeout : float, optional
+        Timeout for GitHub API requests in seconds, by default 5.0.
+
+    Returns
+    -------
+    Github
+        A PyGithub client instance.
+    """
+    pat = get_user_pat()
+    if pat:
+        return Github(auth=Token(pat), timeout=int(timeout))
+    return Github(timeout=int(timeout))
+
+
+def _get_latest_version_github(timeout: float = 5.0) -> tuple[str | None, str | None]:
+    """Query GitHub for the latest siesta version.
+
+    First tries without authentication (public repo), then falls back to
+    PAT authentication if rate-limited or if access is denied.
+
+    Parameters
+    ----------
+    timeout : float, optional
+        Timeout for the HTTP request in seconds, by default 5.0.
+        Note: PyGithub uses its own timeout handling.
+
+    Returns
+    -------
+    tuple[str | None, str | None]
+        ``(version, None)`` on success, ``(None, None)`` if no release/tag was found,
+        or ``(None, err)`` on failure.
+    """
+
+    def try_get_version(g: Github) -> str | None:
+        """Try to get version from releases, then tags."""
+        try:
+            repo = g.get_repo(f"{GITHUB_OWNER}/{GITHUB_REPO}")
+
+            # Try releases first
+            try:
+                release = repo.get_latest_release()
+                tag_name = release.tag_name
+                return tag_name.lstrip("v") if tag_name else None
+            except GithubException as e:
+                # 404 means no releases, try tags
+                if e.status == 404:
+                    pass
+                else:
+                    raise
+
+            # Fall back to tags
+            tags = repo.get_tags()
+            if tags.totalCount > 0:
+                tag_name = tags[0].name
+                return tag_name.lstrip("v") if tag_name else None
+
+        except GithubException:
+            raise
+
+        return None
+
+    unauth_forbidden: GithubException | None = None
+
+    # Try unauthenticated first (public repo)
+    try:
+        g = Github(timeout=int(timeout))
+        result = try_get_version(g)
+        if result:
+            return (result, None)
+    except GithubException as e:
+        # 403 often means rate limited, will try with auth
+        if e.status == 403:
+            unauth_forbidden = e
+        else:
+            logger.warning(f"Failed to fetch latest version from GitHub: {e}")
+            return (None, format_github_access_error(e))
+
+    # Fall back to PAT authentication (for rate limiting)
+    pat = get_user_pat()
+    if pat:
+        try:
+            g = Github(auth=Token(pat), timeout=int(timeout))
+            result = try_get_version(g)
+            if result:
+                return (result, None)
+        except GithubException as e:
+            logger.warning(f"Failed to fetch latest version from GitHub: {e}")
+            return (None, format_github_access_error(e))
+    elif unauth_forbidden is not None:
+        return (None, format_github_access_error(unauth_forbidden))
+
+    return (None, None)
+
+
+def get_latest_github_release_version(
+    timeout: float = 5.0,
+) -> tuple[str | None, str | None]:
+    """Get the latest release version from GitHub.
+
+    Parameters
+    ----------
+    timeout : float, optional
+        Timeout for the HTTP request in seconds, by default 5.0.
+
+    Returns
+    -------
+    tuple[str | None, str | None]
+        ``(version, None)`` on success, ``(None, None)`` if no release or tag was found,
+        or ``(None, error_message)`` if the query failed.
+    """
+    return _get_latest_version_github(timeout=timeout)
+
+
+def get_latest_commit_info(
+    timeout: float = 5.0, branch: str = "main"
+) -> tuple[CommitInfo | None, str | None]:
+    """Get info about the latest commit on a branch from GitHub.
+
+    Parameters
+    ----------
+    timeout : float, optional
+        Timeout for the HTTP request in seconds, by default 5.0.
+    branch : str, optional
+        The branch to get the latest commit from, by default ``"main"``.
+
+    Returns
+    -------
+    tuple[CommitInfo | None, str | None]
+        ``(info, None)`` on success, ``(None, None)`` if the branch has no commits,
+        or ``(None, error_message)`` if the query failed.
+    """
+    try:
+        g = _get_github_client(timeout=timeout)
+        repo = g.get_repo(f"{GITHUB_OWNER}/{GITHUB_REPO}")
+        commits = repo.get_commits(sha=branch)
+        commit = commits[0]
+        return (
+            {
+                "hash": commit.sha[:7],
+                "author": commit.commit.author.name,
+                "time": commit.commit.author.date,
+            },
+            None,
+        )
+    except GithubException as e:
+        return (None, format_github_access_error(e))
+    except IndexError:
+        return (None, None)
+    except Exception as e:
+        return (None, format_github_access_error(e))

--- a/src/siesta/utils/self.py
+++ b/src/siesta/utils/self.py
@@ -29,7 +29,12 @@ from typing import TYPE_CHECKING
 from urllib.error import URLError
 from urllib.request import urlopen
 
-from github import Github, GithubException
+from github import (
+    BadCredentialsException,
+    Github,
+    GithubException,
+    RateLimitExceededException,
+)
 from github.Auth import Token
 from packaging.version import Version
 from platformdirs import user_cache_dir
@@ -46,11 +51,17 @@ from siesta.utils.config import (
 from siesta.utils.github import get_user_pat
 
 if TYPE_CHECKING:
+    from datetime import datetime
     from typing import TypedDict
 
     class CacheData(TypedDict):
         last_check: float
         latest_version: str | None
+
+    class CommitInfo(TypedDict):
+        hash: str
+        author: str
+        time: datetime
 
 
 # Cache file location (uses platform-appropriate directory)
@@ -142,7 +153,34 @@ def get_installation_source() -> str:
     return "pypi"
 
 
-def _get_latest_version_github(timeout: float = 5.0) -> str | None:
+def format_github_access_error(exc: BaseException) -> str:
+    """Summarize a PyGithub or transport error for user-facing messages.
+
+    Parameters
+    ----------
+    exc : BaseException
+        The exception raised when calling the GitHub API.
+
+    Returns
+    -------
+    str
+        A short, human-readable description.
+    """
+    if isinstance(exc, BadCredentialsException):
+        return (
+            "GitHub rejected the token (invalid or expired). "
+            "Run `siesta self set-github-pat` with a valid PAT."
+        )
+    if isinstance(exc, RateLimitExceededException):
+        return "GitHub API rate limit exceeded. Try again later or set a PAT."
+    if isinstance(exc, GithubException):
+        data = exc.data if isinstance(exc.data, dict) else {}
+        msg = data.get("message") or str(exc)
+        return f"GitHub API {exc.status}: {msg}"
+    return str(exc) or type(exc).__name__
+
+
+def _get_latest_version_github(timeout: float = 5.0) -> tuple[str | None, str | None]:
     """Query GitHub for the latest siesta version.
 
     First tries without authentication (public repo), then falls back to
@@ -156,8 +194,9 @@ def _get_latest_version_github(timeout: float = 5.0) -> str | None:
 
     Returns
     -------
-    str | None
-        The latest version string, or ``None`` if the query failed.
+    tuple[str | None, str | None]
+        ``(version, None)`` on success, ``(None, None)`` if no release/tag was found,
+        or ``(None, err)`` on failure.
     """
 
     def try_get_version(g: Github) -> str | None:
@@ -188,17 +227,21 @@ def _get_latest_version_github(timeout: float = 5.0) -> str | None:
 
         return None
 
+    unauth_forbidden: GithubException | None = None
+
     # Try unauthenticated first (public repo)
     try:
         g = Github(timeout=int(timeout))
         result = try_get_version(g)
         if result:
-            return result
+            return (result, None)
     except GithubException as e:
         # 403 often means rate limited, will try with auth
-        if e.status != 403:
+        if e.status == 403:
+            unauth_forbidden = e
+        else:
             logger.warning(f"Failed to fetch latest version from GitHub: {e}")
-            return None
+            return (None, format_github_access_error(e))
 
     # Fall back to PAT authentication (for rate limiting)
     pat = get_user_pat()
@@ -207,14 +250,94 @@ def _get_latest_version_github(timeout: float = 5.0) -> str | None:
             g = Github(auth=Token(pat), timeout=int(timeout))
             result = try_get_version(g)
             if result:
-                return result
+                return (result, None)
         except GithubException as e:
             logger.warning(f"Failed to fetch latest version from GitHub: {e}")
+            return (None, format_github_access_error(e))
+    elif unauth_forbidden is not None:
+        return (None, format_github_access_error(unauth_forbidden))
 
-    return None
+    return (None, None)
 
 
-def _get_latest_version_pypi(timeout: float = 5.0) -> str | None:
+def _get_github_client(timeout: float = 5.0) -> Github:
+    """Get a GitHub client, trying unauthenticated first then falling back to PAT.
+
+    Parameters
+    ----------
+    timeout : float, optional
+        Timeout for GitHub API requests in seconds, by default 5.0.
+
+    Returns
+    -------
+    Github
+        A PyGithub client instance.
+    """
+    pat = get_user_pat()
+    if pat:
+        return Github(auth=Token(pat), timeout=int(timeout))
+    return Github(timeout=int(timeout))
+
+
+def get_latest_github_release_version(
+    timeout: float = 5.0,
+) -> tuple[str | None, str | None]:
+    """Get the latest release version from GitHub.
+
+    Parameters
+    ----------
+    timeout : float, optional
+        Timeout for the HTTP request in seconds, by default 5.0.
+
+    Returns
+    -------
+    tuple[str | None, str | None]
+        ``(version, None)`` on success, ``(None, None)`` if no release or tag was found,
+        or ``(None, error_message)`` if the query failed.
+    """
+    return _get_latest_version_github(timeout=timeout)
+
+
+def get_latest_commit_info(
+    timeout: float = 5.0, branch: str = "main"
+) -> tuple[CommitInfo | None, str | None]:
+    """Get info about the latest commit on a branch from GitHub.
+
+    Parameters
+    ----------
+    timeout : float, optional
+        Timeout for the HTTP request in seconds, by default 5.0.
+    branch : str, optional
+        The branch to get the latest commit from, by default ``"main"``.
+
+    Returns
+    -------
+    tuple[CommitInfo | None, str | None]
+        ``(info, None)`` on success, ``(None, None)`` if the branch has no commits,
+        or ``(None, error_message)`` if the query failed.
+    """
+    try:
+        g = _get_github_client(timeout=timeout)
+        repo = g.get_repo(f"{GITHUB_OWNER}/{GITHUB_REPO}")
+        commits = repo.get_commits(sha=branch)
+        commit = commits[0]
+        return (
+            {
+                "hash": commit.sha[:7],
+                "author": commit.commit.author.name,
+                "time": commit.commit.author.date,
+            },
+            None,
+        )
+    except GithubException as e:
+        return (None, format_github_access_error(e))
+    except IndexError:
+        return (None, None)
+    except Exception as e:
+        return (None, format_github_access_error(e))
+
+
+def _get_latest_version_pypi(timeout: float = 5.0) -> tuple[str | None, str | None]:
     """Query PyPI for the latest siesta version.
 
     Parameters
@@ -224,19 +347,22 @@ def _get_latest_version_pypi(timeout: float = 5.0) -> str | None:
 
     Returns
     -------
-    str | None
-        The latest version string, or ``None`` if the query failed.
+    tuple[str | None, str | None]
+        ``(version, None)`` on success, or ``(None, error_message)`` on failure.
     """
     try:
         with urlopen(PYPI_URL, timeout=timeout) as response:
             data = json.loads(response.read().decode("utf-8"))
-            return data.get("info", {}).get("version")
+            ver = data.get("info", {}).get("version")
+            return (ver, None)
     except (URLError, json.JSONDecodeError, TimeoutError) as e:
         logger.warning(f"Failed to fetch latest version from PyPI: {e}")
-        return None
+        return (None, str(e))
 
 
-def get_latest_version(timeout: float = 5.0, source: str | None = None) -> str | None:
+def get_latest_version(
+    timeout: float = 5.0, source: str | None = None
+) -> tuple[str | None, str | None]:
     """Query the appropriate source for the latest siesta version.
 
     The source is determined by how siesta was installed:
@@ -254,8 +380,8 @@ def get_latest_version(timeout: float = 5.0, source: str | None = None) -> str |
 
     Returns
     -------
-    str | None
-        The latest version string, or ``None`` if the query failed.
+    tuple[str | None, str | None]
+        ``(version, None)`` on success, or ``(None, error_message)`` on failure.
     """
     if source is None:
         source = get_installation_source()
@@ -484,7 +610,7 @@ def _check_for_updates_sync(current_version: str) -> tuple[str, str] | None:
         A tuple of (current_version, latest_version) if an update is available,
         or ``None`` if up to date or check failed.
     """
-    latest = get_latest_version(timeout=3.0)
+    latest, _err = get_latest_version(timeout=3.0)
     _write_cache(latest)
 
     if latest is None:

--- a/src/siesta/utils/self.py
+++ b/src/siesta/utils/self.py
@@ -29,39 +29,24 @@ from typing import TYPE_CHECKING
 from urllib.error import URLError
 from urllib.request import urlopen
 
-from github import (
-    BadCredentialsException,
-    Github,
-    GithubException,
-    RateLimitExceededException,
-)
-from github.Auth import Token
 from packaging.version import Version
 from platformdirs import user_cache_dir
 
 from siesta.utils.common import logger, run_command
 from siesta.utils.config import (
     DEFAULT_UPDATE_CHECK_HOURS,
-    GITHUB_OWNER,
-    GITHUB_REPO,
     PACKAGE_NAME,
     PYPI_URL,
     UPDATE_CHECK_ENV_VAR,
 )
-from siesta.utils.github import get_user_pat
+from siesta.utils.github import _get_latest_version_github
 
 if TYPE_CHECKING:
-    from datetime import datetime
     from typing import TypedDict
 
     class CacheData(TypedDict):
         last_check: float
         latest_version: str | None
-
-    class CommitInfo(TypedDict):
-        hash: str
-        author: str
-        time: datetime
 
 
 # Cache file location (uses platform-appropriate directory)
@@ -151,190 +136,6 @@ def get_installation_source() -> str:
         pass
 
     return "pypi"
-
-
-def format_github_access_error(exc: BaseException) -> str:
-    """Summarize a PyGithub or transport error for user-facing messages.
-
-    Parameters
-    ----------
-    exc : BaseException
-        The exception raised when calling the GitHub API.
-
-    Returns
-    -------
-    str
-        A short, human-readable description.
-    """
-    if isinstance(exc, BadCredentialsException):
-        return (
-            "GitHub rejected the token (invalid or expired). "
-            "Run `siesta self set-github-pat` with a valid PAT."
-        )
-    if isinstance(exc, RateLimitExceededException):
-        return "GitHub API rate limit exceeded. Try again later or set a PAT."
-    if isinstance(exc, GithubException):
-        data = exc.data if isinstance(exc.data, dict) else {}
-        msg = data.get("message") or str(exc)
-        return f"GitHub API {exc.status}: {msg}"
-    return str(exc) or type(exc).__name__
-
-
-def _get_latest_version_github(timeout: float = 5.0) -> tuple[str | None, str | None]:
-    """Query GitHub for the latest siesta version.
-
-    First tries without authentication (public repo), then falls back to
-    PAT authentication if rate-limited or if access is denied.
-
-    Parameters
-    ----------
-    timeout : float, optional
-        Timeout for the HTTP request in seconds, by default 5.0.
-        Note: PyGithub uses its own timeout handling.
-
-    Returns
-    -------
-    tuple[str | None, str | None]
-        ``(version, None)`` on success, ``(None, None)`` if no release/tag was found,
-        or ``(None, err)`` on failure.
-    """
-
-    def try_get_version(g: Github) -> str | None:
-        """Try to get version from releases, then tags."""
-        try:
-            repo = g.get_repo(f"{GITHUB_OWNER}/{GITHUB_REPO}")
-
-            # Try releases first
-            try:
-                release = repo.get_latest_release()
-                tag_name = release.tag_name
-                return tag_name.lstrip("v") if tag_name else None
-            except GithubException as e:
-                # 404 means no releases, try tags
-                if e.status == 404:
-                    pass
-                else:
-                    raise
-
-            # Fall back to tags
-            tags = repo.get_tags()
-            if tags.totalCount > 0:
-                tag_name = tags[0].name
-                return tag_name.lstrip("v") if tag_name else None
-
-        except GithubException:
-            raise
-
-        return None
-
-    unauth_forbidden: GithubException | None = None
-
-    # Try unauthenticated first (public repo)
-    try:
-        g = Github(timeout=int(timeout))
-        result = try_get_version(g)
-        if result:
-            return (result, None)
-    except GithubException as e:
-        # 403 often means rate limited, will try with auth
-        if e.status == 403:
-            unauth_forbidden = e
-        else:
-            logger.warning(f"Failed to fetch latest version from GitHub: {e}")
-            return (None, format_github_access_error(e))
-
-    # Fall back to PAT authentication (for rate limiting)
-    pat = get_user_pat()
-    if pat:
-        try:
-            g = Github(auth=Token(pat), timeout=int(timeout))
-            result = try_get_version(g)
-            if result:
-                return (result, None)
-        except GithubException as e:
-            logger.warning(f"Failed to fetch latest version from GitHub: {e}")
-            return (None, format_github_access_error(e))
-    elif unauth_forbidden is not None:
-        return (None, format_github_access_error(unauth_forbidden))
-
-    return (None, None)
-
-
-def _get_github_client(timeout: float = 5.0) -> Github:
-    """Get a GitHub client, trying unauthenticated first then falling back to PAT.
-
-    Parameters
-    ----------
-    timeout : float, optional
-        Timeout for GitHub API requests in seconds, by default 5.0.
-
-    Returns
-    -------
-    Github
-        A PyGithub client instance.
-    """
-    pat = get_user_pat()
-    if pat:
-        return Github(auth=Token(pat), timeout=int(timeout))
-    return Github(timeout=int(timeout))
-
-
-def get_latest_github_release_version(
-    timeout: float = 5.0,
-) -> tuple[str | None, str | None]:
-    """Get the latest release version from GitHub.
-
-    Parameters
-    ----------
-    timeout : float, optional
-        Timeout for the HTTP request in seconds, by default 5.0.
-
-    Returns
-    -------
-    tuple[str | None, str | None]
-        ``(version, None)`` on success, ``(None, None)`` if no release or tag was found,
-        or ``(None, error_message)`` if the query failed.
-    """
-    return _get_latest_version_github(timeout=timeout)
-
-
-def get_latest_commit_info(
-    timeout: float = 5.0, branch: str = "main"
-) -> tuple[CommitInfo | None, str | None]:
-    """Get info about the latest commit on a branch from GitHub.
-
-    Parameters
-    ----------
-    timeout : float, optional
-        Timeout for the HTTP request in seconds, by default 5.0.
-    branch : str, optional
-        The branch to get the latest commit from, by default ``"main"``.
-
-    Returns
-    -------
-    tuple[CommitInfo | None, str | None]
-        ``(info, None)`` on success, ``(None, None)`` if the branch has no commits,
-        or ``(None, error_message)`` if the query failed.
-    """
-    try:
-        g = _get_github_client(timeout=timeout)
-        repo = g.get_repo(f"{GITHUB_OWNER}/{GITHUB_REPO}")
-        commits = repo.get_commits(sha=branch)
-        commit = commits[0]
-        return (
-            {
-                "hash": commit.sha[:7],
-                "author": commit.commit.author.name,
-                "time": commit.commit.author.date,
-            },
-            None,
-        )
-    except GithubException as e:
-        return (None, format_github_access_error(e))
-    except IndexError:
-        return (None, None)
-    except Exception as e:
-        return (None, format_github_access_error(e))
 
 
 def _get_latest_version_pypi(timeout: float = 5.0) -> tuple[str | None, str | None]:

--- a/tests/test_cli/test_self.py
+++ b/tests/test_cli/test_self.py
@@ -10,6 +10,7 @@ from siesta.cli import app
 from siesta.utils.self import (
     PACKAGE_NAME,
     compare_versions,
+    format_github_access_error,
     get_installation_method,
     get_installation_source,
     get_latest_version,
@@ -127,7 +128,7 @@ class TestGetLatestVersion:
         mock_response.__exit__ = MagicMock(return_value=False)
 
         with patch("siesta.utils.self.urlopen", return_value=mock_response):
-            assert get_latest_version(source="pypi") == "2.0.0"
+            assert get_latest_version(source="pypi") == ("2.0.0", None)
 
     def test_returns_version_from_github_release(self):
         """Test successful version fetch from GitHub releases."""
@@ -141,7 +142,7 @@ class TestGetLatestVersion:
         mock_github.get_repo.return_value = mock_repo
 
         with patch("siesta.utils.self.Github", return_value=mock_github):
-            assert get_latest_version(source="github") == "2.0.0"
+            assert get_latest_version(source="github") == ("2.0.0", None)
 
     def test_returns_version_from_github_tags_fallback(self):
         """Test fallback to GitHub tags when no releases exist."""
@@ -164,14 +165,17 @@ class TestGetLatestVersion:
         mock_github.get_repo.return_value = mock_repo
 
         with patch("siesta.utils.self.Github", return_value=mock_github):
-            assert get_latest_version(source="github") == "1.5.0"
+            assert get_latest_version(source="github") == ("1.5.0", None)
 
     def test_returns_none_on_pypi_network_error(self):
         """Test None is returned on PyPI network failure."""
         from urllib.error import URLError
 
         with patch("siesta.utils.self.urlopen", side_effect=URLError("Network error")):
-            assert get_latest_version(source="pypi") is None
+            assert get_latest_version(source="pypi") == (
+                None,
+                "<urlopen error Network error>",
+            )
 
     def test_returns_none_on_pypi_json_error(self):
         """Test None is returned on invalid JSON response from PyPI."""
@@ -181,7 +185,9 @@ class TestGetLatestVersion:
         mock_response.__exit__ = MagicMock(return_value=False)
 
         with patch("siesta.utils.self.urlopen", return_value=mock_response):
-            assert get_latest_version(source="pypi") is None
+            ver, err = get_latest_version(source="pypi")
+            assert ver is None
+            assert err is not None
 
     def test_auto_detects_source(self):
         """Test that source is auto-detected when not specified."""
@@ -194,7 +200,29 @@ class TestGetLatestVersion:
             patch("siesta.utils.self.get_installation_source", return_value="pypi"),
             patch("siesta.utils.self.urlopen", return_value=mock_response),
         ):
-            assert get_latest_version() == "3.0.0"
+            assert get_latest_version() == ("3.0.0", None)
+
+
+class TestFormatGithubAccessError:
+    """Tests for format_github_access_error()."""
+
+    def test_bad_credentials_message(self):
+        """BadCredentialsException maps to PAT guidance."""
+        from github import BadCredentialsException
+
+        msg = format_github_access_error(
+            BadCredentialsException(401, {"message": "Bad credentials"})
+        )
+        assert "token" in msg.lower()
+        assert "set-github-pat" in msg
+
+    def test_github_exception_includes_status(self):
+        """Generic GithubException includes HTTP status and API message."""
+        from github import GithubException
+
+        msg = format_github_access_error(GithubException(404, {"message": "Not Found"}))
+        assert "404" in msg
+        assert "Not Found" in msg
 
 
 class TestCompareVersions:
@@ -254,11 +282,26 @@ class TestGetUpdateCommand:
 class TestSelfVersionCommand:
     """Tests for 'siesta self version' command."""
 
-    def test_version_command_shows_version(self, capture_output):
-        """Test that version command shows current version."""
+    def _mock_commit_info(self):
+        from datetime import datetime, timezone
+
+        return {
+            "hash": "abc1234",
+            "author": "Test User",
+            "time": datetime(2025, 6, 15, 12, 0, 0, tzinfo=timezone.utc),
+        }
+
+    def test_version_command_shows_all_versions(self, capture_output):
+        """Test that version command shows pip, release, and commit info."""
         with (
-            patch("siesta.cli.get_latest_version", return_value=__version__),
-            patch("siesta.cli.get_installation_method", return_value="pip"),
+            patch(
+                "siesta.cli.get_latest_github_release_version",
+                return_value=(__version__, None),
+            ),
+            patch(
+                "siesta.cli.get_latest_commit_info",
+                return_value=(self._mock_commit_info(), None),
+            ),
             capture_output() as output,
         ):
             try:
@@ -268,12 +311,20 @@ class TestSelfVersionCommand:
 
         output_str = output.getvalue()
         assert __version__ in output_str
+        assert "abc1234" in output_str
+        assert "Test User" in output_str
 
     def test_version_command_shows_update_available(self, capture_output):
         """Test that version command shows when update is available."""
         with (
-            patch("siesta.cli.get_latest_version", return_value="99.0.0"),
-            patch("siesta.cli.get_installation_method", return_value="pip"),
+            patch(
+                "siesta.cli.get_latest_github_release_version",
+                return_value=("99.0.0", None),
+            ),
+            patch(
+                "siesta.cli.get_latest_commit_info",
+                return_value=(self._mock_commit_info(), None),
+            ),
             capture_output() as output,
         ):
             try:
@@ -283,6 +334,29 @@ class TestSelfVersionCommand:
 
         output_str = output.getvalue()
         assert "newer version" in output_str.lower() or "99.0.0" in output_str
+
+    def test_version_command_handles_network_errors(self, capture_output):
+        """Test that version command surfaces fetch failure details."""
+        with (
+            patch(
+                "siesta.cli.get_latest_github_release_version",
+                return_value=(None, "GitHub API 401: Bad credentials"),
+            ),
+            patch(
+                "siesta.cli.get_latest_commit_info",
+                return_value=(None, "GitHub API 401: Bad credentials"),
+            ),
+            capture_output() as output,
+        ):
+            try:
+                app(["self", "version"])
+            except SystemExit:
+                pass
+
+        output_str = output.getvalue()
+        assert __version__ in output_str
+        assert "could not fetch" in output_str.lower()
+        assert "401" in output_str
 
 
 class TestSelfUpdateCommand:
@@ -306,7 +380,7 @@ class TestSelfUpdateCommand:
         """Test update command when already on latest version."""
         with (
             patch("siesta.cli.get_installation_method", return_value="pip"),
-            patch("siesta.cli.get_latest_version", return_value=__version__),
+            patch("siesta.cli.get_latest_version", return_value=(__version__, None)),
             capture_output() as output,
         ):
             try:
@@ -321,7 +395,7 @@ class TestSelfUpdateCommand:
         """Test that 'upgrade' is an alias for 'update'."""
         with (
             patch("siesta.cli.get_installation_method", return_value="pip"),
-            patch("siesta.cli.get_latest_version", return_value=__version__),
+            patch("siesta.cli.get_latest_version", return_value=(__version__, None)),
             capture_output() as output,
         ):
             try:

--- a/tests/test_cli/test_self.py
+++ b/tests/test_cli/test_self.py
@@ -7,10 +7,10 @@ import pytest
 
 from siesta import __version__
 from siesta.cli import app
+from siesta.utils.github import format_github_access_error
 from siesta.utils.self import (
     PACKAGE_NAME,
     compare_versions,
-    format_github_access_error,
     get_installation_method,
     get_installation_source,
     get_latest_version,
@@ -141,7 +141,7 @@ class TestGetLatestVersion:
         mock_github = MagicMock()
         mock_github.get_repo.return_value = mock_repo
 
-        with patch("siesta.utils.self.Github", return_value=mock_github):
+        with patch("siesta.utils.github.Github", return_value=mock_github):
             assert get_latest_version(source="github") == ("2.0.0", None)
 
     def test_returns_version_from_github_tags_fallback(self):
@@ -164,7 +164,7 @@ class TestGetLatestVersion:
         mock_github = MagicMock()
         mock_github.get_repo.return_value = mock_repo
 
-        with patch("siesta.utils.self.Github", return_value=mock_github):
+        with patch("siesta.utils.github.Github", return_value=mock_github):
             assert get_latest_version(source="github") == ("1.5.0", None)
 
     def test_returns_none_on_pypi_network_error(self):

--- a/tests/test_cli/test_self.py
+++ b/tests/test_cli/test_self.py
@@ -225,6 +225,96 @@ class TestFormatGithubAccessError:
         assert "Not Found" in msg
 
 
+class TestGetLatestCommitInfo:
+    """Tests for get_latest_commit_info()."""
+
+    def _make_mock_commit(self, sha: str, author: str, date):
+        mock_author = MagicMock()
+        mock_author.name = author
+        mock_author.date = date
+
+        mock_commit_obj = MagicMock()
+        mock_commit_obj.author = mock_author
+
+        mock_commit = MagicMock()
+        mock_commit.sha = sha
+        mock_commit.commit = mock_commit_obj
+        return mock_commit
+
+    def test_returns_commit_info_on_success(self):
+        """Returns hash, author, and time for the latest commit."""
+        from datetime import datetime, timezone
+
+        from siesta.utils.github import get_latest_commit_info
+
+        date = datetime(2025, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+        mock_commit = self._make_mock_commit("abc1234def", "Test User", date)
+
+        mock_commits = MagicMock()
+        mock_commits.__getitem__ = MagicMock(return_value=mock_commit)
+
+        mock_repo = MagicMock()
+        mock_repo.get_commits.return_value = mock_commits
+
+        mock_github = MagicMock()
+        mock_github.get_repo.return_value = mock_repo
+
+        with (
+            patch("siesta.utils.github.Github", return_value=mock_github),
+            patch("siesta.utils.github.get_user_pat", return_value=None),
+        ):
+            info, err = get_latest_commit_info()
+
+        assert err is None
+        assert info is not None
+        assert info["hash"] == "abc1234"
+        assert info["author"] == "Test User"
+        assert info["time"] == date
+
+    def test_returns_none_on_github_exception(self):
+        """GithubException is caught and error string is returned."""
+        from github import GithubException
+
+        from siesta.utils.github import get_latest_commit_info
+
+        mock_github = MagicMock()
+        mock_github.get_repo.side_effect = GithubException(
+            403, {"message": "Forbidden"}
+        )
+
+        with (
+            patch("siesta.utils.github.Github", return_value=mock_github),
+            patch("siesta.utils.github.get_user_pat", return_value=None),
+        ):
+            info, err = get_latest_commit_info()
+
+        assert info is None
+        assert err is not None
+        assert "403" in err
+
+    def test_returns_none_none_on_index_error(self):
+        """Empty commit list (IndexError) returns (None, None)."""
+        from siesta.utils.github import get_latest_commit_info
+
+        mock_commits = MagicMock()
+        mock_commits.__getitem__ = MagicMock(side_effect=IndexError)
+
+        mock_repo = MagicMock()
+        mock_repo.get_commits.return_value = mock_commits
+
+        mock_github = MagicMock()
+        mock_github.get_repo.return_value = mock_repo
+
+        with (
+            patch("siesta.utils.github.Github", return_value=mock_github),
+            patch("siesta.utils.github.get_user_pat", return_value=None),
+        ):
+            info, err = get_latest_commit_info()
+
+        assert info is None
+        assert err is None
+
+
 class TestCompareVersions:
     """Tests for compare_versions()."""
 


### PR DESCRIPTION
## TL;DR

Enhance `siesta self version` to display three sources of truth — the installed pip version, the latest GitHub release, and the latest commit on `main` — and propagate error details instead of silently returning `None` when version checks fail.

## Breaking changes 🔥

- 🟡 **`get_latest_version` return type changed**: Now returns `tuple[str | None, str | None]` instead of `str | None`. Any caller outside this repo that unpacks the return value will break silently.

## Changes

- **`siesta self version` output**: Replace the single PyPI/GitHub version line and installation-method display with three labeled lines — installed pip version, GitHub latest release, and latest commit hash/author/time on `main`.
- **Error propagation**: `get_latest_version`, `_get_latest_version_pypi`, and `_get_latest_version_github` now return `(value, error_str)` tuples so callers can surface failure details to the user rather than swallowing them.
- **GitHub utilities**: Move `_get_latest_version_github` from `self.py` into `github.py` (where the other GitHub API logic lives), and add `get_latest_github_release_version`, `get_latest_commit_info`, `format_github_access_error`, and `_get_github_client` helpers.
- **Tests**: Update all affected `get_latest_version` assertions for the new tuple return, update mock patch paths to `siesta.utils.github.Github`, and add tests for `format_github_access_error` and the network-error path in the version command.

## Review hints

- `cli.py:self_version` (around line 1011) fires two GitHub API calls inside a single `logger.loading` block — `get_latest_github_release_version` and `get_latest_commit_info` run sequentially, not in parallel.
- No DB, config schema, or CLI surface area outside `self version`/`self update` is touched.
