### PR TITLE
feat: add managed shell tab-completion support (bash/zsh)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "siesta"
-version = "1.1.1"
+version = "1.2.0"
 description = "Entalpic's Development Guidelines & Docs CLI"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "rich>=13.9.4",
-    "cyclopts>=2.9.9",
+    "cyclopts>=4.4.5",
     "pygithub>=2.5.0",
     "keyring>=25.5.0",
     "ruamel-yaml>=0.18.6",

--- a/src/siesta/cli.py
+++ b/src/siesta/cli.py
@@ -293,7 +293,7 @@ def where(*, shell: Shell | None = None, simple: bool = False) -> None:
         (
             "hook_file",
             "Hook file",
-            f"Sourced by ~/{''.join(['.bashrc' if resolved == 'bash' else '.zshrc'])} "
+            f"Sourced by ~/{'.bashrc' if resolved == 'bash' else '.zshrc'} "
             "at shell startup. Sources the static script and wraps the CLI command.",
         ),
         (
@@ -363,21 +363,21 @@ def uninstall(*, shell: Shell | None = None) -> None:
         rprint("[dim]Nothing to remove.[/dim]")
 
 
-# ---------------------------------------------------------------------------
-# Completion installation hint (shown in --help when not installed)
-# ---------------------------------------------------------------------------
-
-_current_shell = detect_current_shell()
-if _current_shell is None or not is_completion_installed(_current_shell):
-    _shell_flag = " --shell <bash|zsh>" if _current_shell is None else ""
-    app.help_epilogue = (
-        f"Tip: enable tab completions with "
-        f"`siesta self tab-completions install{_shell_flag}`"
-    )
+def _set_completion_hint() -> None:
+    """Show a tab-completion install tip in ``--help`` when not already installed."""
+    current_shell = detect_current_shell()
+    if current_shell is None or not is_completion_installed(current_shell):
+        shell_flag = " --shell <bash|zsh>" if current_shell is None else ""
+        app.help_epilogue = (
+            f"Tip: enable tab completions with "
+            f"`siesta self tab-completions install{shell_flag}`"
+        )
 
 
 def main():
     """Run the CLI, gracefully handling ``KeyboardInterrupt``."""
+    _set_completion_hint()
+
     # Start background update check (non-blocking)
     update_future = start_background_update_check(metadata.version("siesta"))
     interrupted = False

--- a/src/siesta/cli.py
+++ b/src/siesta/cli.py
@@ -40,10 +40,12 @@ You can also refer to the :ref:`siesta-cli-tutorial` for more information.
 
 """
 
+import builtins
 import getpass
 import os
 import platform
 import subprocess
+import sys
 import time
 from importlib import metadata
 from pathlib import Path
@@ -53,8 +55,10 @@ from typing import Annotated, Optional
 
 from cyclopts import App, Parameter
 from gitignore_parser import parse_gitignore
+from rich import print as rprint
 from watchdog.observers import Observer
 
+from siesta.completions import Shell, detect_current_shell, is_completion_installed
 from siesta.utils.common import (
     get_project_name,
     load_deps,
@@ -158,6 +162,218 @@ self_app = App(
 app.command(docs_app)
 app.command(project_app)
 app.command(self_app)
+
+# ============================================================================
+# Tab completions sub-app (under `siesta self tab-completions`)
+# ============================================================================
+
+tab_completions_app = App(
+    name="tab-completions",
+    help="Command group — manage shell tab completions (requires a subcommand).",
+)
+self_app.command(tab_completions_app)
+
+
+def _resolve_shell(shell: Shell | None) -> Shell:
+    """Return ``shell`` if given, otherwise detect and return the current shell.
+
+    Parameters
+    ----------
+    shell : Shell | None
+        Explicitly provided shell value, or ``None`` to auto-detect.
+
+    Returns
+    -------
+    Shell
+        The resolved shell (``"bash"`` or ``"zsh"``).
+    """
+    if shell is not None:
+        return shell
+    detected = detect_current_shell()
+    if detected is None:
+        rprint(
+            "[red]Cannot detect current shell. "
+            "Please specify --shell bash or --shell zsh.[/red]"
+        )
+        sys.exit(1)
+    return detected
+
+
+@tab_completions_app.command
+def install(
+    *,
+    shell: Shell | None = None,
+    add_to_startup: bool = True,
+) -> None:
+    """Install tab completions for the current (or specified) shell.
+
+    Writes managed hook and static completion script files to the
+    shell-specific XDG config path, and optionally adds a source line to the
+    shell RC file.
+
+    Parameters
+    ----------
+    shell : {'bash', 'zsh'} | None, optional
+        Target shell. Defaults to the current shell detected from ``$SHELL``.
+        Required when the current shell cannot be detected.
+    add_to_startup : bool, optional
+        When ``True`` (default), append a source line to ``~/.bashrc`` or
+        ``~/.zshrc`` so completions activate in every new shell session.
+        Use ``--no-add-to-startup`` to write the files without editing the RC
+        file.
+    """
+    from siesta.completions import install_managed_completion
+
+    resolved = _resolve_shell(shell)
+    path = install_managed_completion(
+        shell=resolved,
+        generate_fn=app.generate_completion,
+        add_to_startup=add_to_startup,
+    )
+    rprint(f"[green]Managed completion installed to {path}[/green]")
+    if add_to_startup:
+        rc = ".bashrc" if resolved == "bash" else ".zshrc"
+        rprint(
+            f"[dim]Restart your shell or run `source ~/{rc}` "
+            "to activate completions now.[/dim]"
+        )
+
+
+@tab_completions_app.command
+def show(*, shell: Shell | None = None) -> None:
+    """Print the tab completion script to stdout (without installing).
+
+    Outputs the raw completion script for the given shell; suitable for
+    manual sourcing or inspection.
+
+    Parameters
+    ----------
+    shell : {'bash', 'zsh'} | None, optional
+        Target shell. Defaults to the current shell detected from ``$SHELL``.
+        Required when the current shell cannot be detected.
+    """
+    resolved = _resolve_shell(shell)
+    builtins.print(app.generate_completion(shell=resolved), end="")
+
+
+@tab_completions_app.command
+def where(*, shell: Shell | None = None, simple: bool = False) -> None:
+    """Display where managed completion files are stored.
+
+    By default shows a table with the path, existence status, and purpose of
+    each managed file. Use ``--simple`` for plain-text output (one path per
+    line), which is handy for scripting.
+
+    Parameters
+    ----------
+    shell : {'bash', 'zsh'} | None, optional
+        Target shell. Defaults to the current shell detected from ``$SHELL``.
+        Required when the current shell cannot be detected.
+    simple : bool, optional
+        When ``True``, print one ``<label>: <path>`` line per file with no
+        table formatting or descriptions.
+    """
+    from siesta.completions import (
+        managed_completion_paths,
+        resolve_cli_executable,
+        stable_exec_id,
+    )
+
+    resolved = _resolve_shell(shell)
+    exec_path = resolve_cli_executable()
+    exec_id = stable_exec_id(exec_path)
+    paths = managed_completion_paths(shell=resolved, exec_id=exec_id)
+
+    _ENTRIES = [
+        (
+            "base_dir",
+            "Base directory",
+            "Root folder for all managed completion files for this shell.",
+        ),
+        (
+            "hook_file",
+            "Hook file",
+            f"Sourced by ~/{''.join(['.bashrc' if resolved == 'bash' else '.zshrc'])} "
+            "at shell startup. Sources the static script and wraps the CLI command.",
+        ),
+        (
+            "static_file",
+            "Static completion script",
+            "Cached completion script generated by the CLI framework. "
+            "Sourced instantly at startup — no Python spawned. Its mtime "
+            "tracks the installed CLI version for staleness detection.",
+        ),
+    ]
+
+    if simple:
+        for key, label, _ in _ENTRIES:
+            p: Path = paths[key]
+            exists = "[green]exists[/green]" if p.exists() else "[dim]missing[/dim]"
+            rprint(f"[bold]{label}:[/bold] {p}  ({exists})")
+        return
+
+    from rich.table import Table
+
+    table = Table(
+        title=f"Managed completion paths — [cyan]{resolved}[/cyan]",
+        show_lines=True,
+    )
+    table.add_column("File", style="bold", no_wrap=True)
+    table.add_column("Status", no_wrap=True)
+    table.add_column("Path", no_wrap=True)
+    table.add_column("Description")
+
+    for key, label, description in _ENTRIES:
+        p = paths[key]
+        status = "[green]exists[/green]" if p.exists() else "[dim]missing[/dim]"
+        table.add_row(label, status, str(p), description)
+
+    rprint(table)
+
+
+@tab_completions_app.command
+def uninstall(*, shell: Shell | None = None) -> None:
+    """Remove managed tab completions for the current (or specified) shell.
+
+    Deletes the hook file and cached completion script for the currently
+    active ``siesta`` executable, and strips the source line from the shell
+    RC file.  Files belonging to other siesta installations are left
+    untouched.
+
+    Parameters
+    ----------
+    shell : {'bash', 'zsh'} | None, optional
+        Target shell. Defaults to the current shell detected from ``$SHELL``.
+        Required when the current shell cannot be detected.
+    """
+    from siesta.completions import uninstall_managed_completion
+
+    resolved = _resolve_shell(shell)
+    result = uninstall_managed_completion(shell=resolved)
+    removed: list[Path] = result["removed"]
+    missing: list[Path] = result["missing"]
+
+    if removed:
+        for p in removed:
+            rprint(f"[green]Removed: {p}[/green]")
+    if missing:
+        for p in missing:
+            rprint(f"[dim]Not found (skipped): {p}[/dim]")
+    if not removed and not missing:
+        rprint("[dim]Nothing to remove.[/dim]")
+
+
+# ---------------------------------------------------------------------------
+# Completion installation hint (shown in --help when not installed)
+# ---------------------------------------------------------------------------
+
+_current_shell = detect_current_shell()
+if _current_shell is None or not is_completion_installed(_current_shell):
+    _shell_flag = " --shell <bash|zsh>" if _current_shell is None else ""
+    app.help_epilogue = (
+        f"Tip: enable tab completions with "
+        f"`siesta self tab-completions install{_shell_flag}`"
+    )
 
 
 def main():

--- a/src/siesta/completions.py
+++ b/src/siesta/completions.py
@@ -102,6 +102,24 @@ a different CLI tool.
 """
 
 
+def _shell_quote(path: str | Path) -> str:
+    """Single-quote a string for safe embedding in a shell script.
+
+    Uses the standard ``'\''`` idiom to handle embedded single-quotes.
+
+    Parameters
+    ----------
+    path : str | Path
+        Value to quote.
+
+    Returns
+    -------
+    str
+        Shell-safe single-quoted string (e.g. ``'/some/path'``).
+    """
+    return "'" + str(path).replace("'", "'\\''") + "'"
+
+
 # ---------------------------------------------------------------------------
 # Executable resolution
 # ---------------------------------------------------------------------------
@@ -190,7 +208,7 @@ def managed_completion_paths(shell: Shell, exec_id: str) -> dict[str, Path]:
             script.  Its mtime is kept in sync with the CLI executable for
             staleness detection.
     """
-    xdg_config_home = os.environ.get("XDG_CONFIG_HOME")
+    xdg_config_home = os.environ.get("XDG_CONFIG_HOME", "").strip()
     config_root = (
         Path(xdg_config_home).expanduser()
         if xdg_config_home
@@ -233,7 +251,7 @@ def render_shell_hook(shell: Shell, *, base_dir: Path) -> str:
     str
         Complete shell script text to be written to ``hook.<shell>``.
     """
-    base_dir_str = str(base_dir)
+    base_dir_q = _shell_quote(base_dir)
     if shell == "bash":
         return textwrap.dedent(f"""\
             # {_CLI_NAME} managed completion hook (bash)
@@ -243,14 +261,21 @@ def render_shell_hook(shell: Shell, *, base_dir: Path) -> str:
             # Unset inherited guard so every new shell starts fresh.
             unset _{_CLI_NAME.upper()}_COMPLETION_REFRESHED 2>/dev/null
 
-            _{_CLI_NAME}_completion_base_dir="{base_dir_str}"
+            _{_CLI_NAME}_completion_base_dir={base_dir_q}
+
+            # Portable SHA-256: try sha256sum (coreutils/Linux) then shasum (macOS).
+            _{_CLI_NAME}_sha256_16() {{
+              local hash
+              hash="$(printf '%s' "$1" | sha256sum 2>/dev/null || printf '%s' "$1" | shasum -a 256 2>/dev/null)" || return 1
+              printf '%s' "${{hash%% *}}" | cut -c1-16
+            }}
 
             # Resolve executable and exec_id once at startup (no Python spawned).
             _{_CLI_NAME}_exec_path="$(command -v {_CLI_NAME} 2>/dev/null || true)"
             _{_CLI_NAME}_exec_id=""
             _{_CLI_NAME}_static_file=""
             if [[ -n "${{_{_CLI_NAME}_exec_path}}" ]]; then
-              _{_CLI_NAME}_exec_id="$(printf '%s' "${{_{_CLI_NAME}_exec_path}}" | shasum -a 256 2>/dev/null | awk '{{print $1}}' | cut -c1-16)"
+              _{_CLI_NAME}_exec_id="$(_{_CLI_NAME}_sha256_16 "${{_{_CLI_NAME}_exec_path}}")"
               [[ -z "${{_{_CLI_NAME}_exec_id}}" ]] && _{_CLI_NAME}_exec_id="${{_{_CLI_NAME}_exec_path//\\//__}}"
               _{_CLI_NAME}_static_file="${{_{_CLI_NAME}_completion_base_dir}}/static-${{_{_CLI_NAME}_exec_id}}.bash"
               if [[ -f "${{_{_CLI_NAME}_static_file}}" ]]; then
@@ -294,7 +319,14 @@ def render_shell_hook(shell: Shell, *, base_dir: Path) -> str:
         # Unset inherited guard so every new shell starts fresh.
         unset _{_CLI_NAME.upper()}_COMPLETION_REFRESHED 2>/dev/null
 
-        _{_CLI_NAME}_completion_base_dir="{base_dir_str}"
+        _{_CLI_NAME}_completion_base_dir={base_dir_q}
+
+        # Portable SHA-256: try sha256sum (coreutils/Linux) then shasum (macOS).
+        _{_CLI_NAME}_sha256_16() {{
+          local hash
+          hash="$(printf '%s' "$1" | sha256sum 2>/dev/null || printf '%s' "$1" | shasum -a 256 2>/dev/null)" || return 1
+          printf '%s' "${{hash%% *}}" | cut -c1-16
+        }}
 
         # zsh: prefer whence -p for reliable absolute-path resolution; fall back to
         # command -v and reject relative paths (e.g. from a local ./{_CLI_NAME}).
@@ -314,7 +346,7 @@ def render_shell_hook(shell: Shell, *, base_dir: Path) -> str:
         _{_CLI_NAME}_exec_id=""
         _{_CLI_NAME}_static_file=""
         if [[ -n "${{_{_CLI_NAME}_exec_path}}" ]]; then
-          _{_CLI_NAME}_exec_id="$(printf '%s' "${{_{_CLI_NAME}_exec_path}}" | shasum -a 256 2>/dev/null | awk '{{print $1}}' | cut -c1-16)"
+          _{_CLI_NAME}_exec_id="$(_{_CLI_NAME}_sha256_16 "${{_{_CLI_NAME}_exec_path}}")"
           [[ -z "${{_{_CLI_NAME}_exec_id}}" ]] && _{_CLI_NAME}_exec_id="${{_{_CLI_NAME}_exec_path//\\//__}}"
           _{_CLI_NAME}_static_file="${{_{_CLI_NAME}_completion_base_dir}}/static-${{_{_CLI_NAME}_exec_id}}.zsh"
           [[ -f "${{_{_CLI_NAME}_static_file}}" ]] && source "${{_{_CLI_NAME}_static_file}}"
@@ -335,7 +367,7 @@ def render_shell_hook(shell: Shell, *, base_dir: Path) -> str:
 
           if [[ "${{current_exec}}" != "${{_{_CLI_NAME}_exec_path}}" ]]; then
             _{_CLI_NAME}_exec_path="${{current_exec}}"
-            _{_CLI_NAME}_exec_id="$(printf '%s' "${{_{_CLI_NAME}_exec_path}}" | shasum -a 256 2>/dev/null | awk '{{print $1}}' | cut -c1-16)"
+            _{_CLI_NAME}_exec_id="$(_{_CLI_NAME}_sha256_16 "${{_{_CLI_NAME}_exec_path}}")"
             [[ -z "${{_{_CLI_NAME}_exec_id}}" ]] && _{_CLI_NAME}_exec_id="${{_{_CLI_NAME}_exec_path//\\//__}}"
             _{_CLI_NAME}_static_file="${{_{_CLI_NAME}_completion_base_dir}}/static-${{_{_CLI_NAME}_exec_id}}.zsh"
           fi
@@ -411,7 +443,8 @@ def ensure_rc_source_line(shell: Shell, hook_file: Path) -> None:
     if not rc_file.exists():
         rc_file.write_text("", encoding="utf-8")
 
-    source_line = f'[[ -f "{hook_file}" ]] && source "{hook_file}"'
+    hook_q = _shell_quote(hook_file)
+    source_line = f"[[ -f {hook_q} ]] && source {hook_q}"
     content = rc_file.read_text(encoding="utf-8")
     if source_line not in content:
         with rc_file.open("a", encoding="utf-8") as fh:
@@ -438,7 +471,8 @@ def remove_rc_source_line(shell: Shell, hook_file: Path) -> None:
     if not rc_file.exists():
         return
 
-    source_line = f'[[ -f "{hook_file}" ]] && source "{hook_file}"'
+    hook_q = _shell_quote(hook_file)
+    source_line = f"[[ -f {hook_q} ]] && source {hook_q}"
     comment_line = f"# {_CLI_NAME} managed completion"
     content = rc_file.read_text(encoding="utf-8")
 

--- a/src/siesta/completions.py
+++ b/src/siesta/completions.py
@@ -1,0 +1,617 @@
+# Copyright 2025 Entalpic
+"""
+Shell tab-completion management for CLI tool.
+
+Overview
+--------
+This module provides all logic for generating, installing, and uninstalling
+bash/zsh tab completions for a CLI.  It is deliberately kept free of any
+CLI-framework (cyclopts) dependency so that it can be imported and tested in
+isolation; the actual ``generate_completion`` callable is injected by the
+caller.
+
+The CLI name is controlled by the module-level :data:`_CLI_NAME` constant.
+All shell variable names, hook file comments, and config-directory path
+components are derived from it, making the module straightforward to adapt
+for different CLI tools by changing a single value.
+
+Modes of operation
+------------------
+**Print mode** (default)
+    The caller obtains the raw completion script from the CLI framework and
+    writes it to stdout.  Users can source it manually or pipe it to a file.
+
+**Managed install mode** (``siesta self tab-completions install``)
+    Two files are written under an XDG-compliant directory tree::
+
+        $XDG_CONFIG_HOME/<cli>/completions/<shell>/
+            hook.<shell>              – sourced by the shell RC file at startup
+            static-<exec_id>.<shell>  – cached completion script
+
+    A source line is optionally appended to the shell RC file
+    (``~/.bashrc`` / ``~/.zshrc``).
+
+How the managed hook works
+--------------------------
+At shell startup the hook:
+
+1. Resolves the CLI executable path **without** spawning Python.
+2. Derives the ``exec_id`` (SHA-256 hex of the path, first 16 chars) used to
+   locate the shell-specific cached completion file.
+3. Sources the cached static file immediately so completions are available
+   without any Python startup overhead.
+
+On the **first real invocation** of the CLI in a session the hook runs
+``_<cli>_maybe_refresh``, which:
+
+4. Compares the executable's mtime to the static completion file.  If the
+   binary is newer (i.e. the CLI was reinstalled or upgraded), it regenerates
+   the cached script by calling
+   ``<cli> self tab-completions show --shell <shell>`` exactly once, then
+   re-sources it.
+5. Sets ``_<CLI>_COMPLETION_REFRESHED=1`` so subsequent invocations in the
+   same session skip the check entirely.
+
+Python is **never** spawned at shell startup — only on the first use after an
+upgrade.
+
+Multi-install support
+---------------------
+Multiple installations (e.g. different virtual-environments or pip-installed
+versions) are isolated by their ``exec_id``.  Each installation gets its own
+``static-<exec_id>.<shell>`` file under the shared base directory.  Switching
+between environments in a new shell session transparently picks up the correct
+completion script.
+
+Bash vs. zsh differences
+-------------------------
+Both shells share the same high-level logic but differ in a few details:
+
+* **Path resolution**: bash uses ``command -v``; zsh uses ``whence -p`` with a
+  ``command -v`` fallback (absolute-path check) for reliability.
+* **Completion registration**: zsh additionally calls ``compdef`` to hook the
+  completion function into the zsh completion system.
+* **Mid-session path change detection**: the zsh hook re-resolves the
+  executable path on every ``_<cli>_maybe_refresh`` call, so switching virtual
+  environments mid-session is handled correctly.  The bash hook does not
+  re-resolve mid-session (resolved once at startup), which is acceptable given
+  bash's usage patterns.
+
+Uninstall
+---------
+:func:`uninstall_managed_completion` removes all managed files for the current
+``exec_id`` and strips the RC source line.  Files for *other* exec_ids
+(i.e. other installations) are left untouched.
+"""
+
+import hashlib
+import os
+import shutil
+import textwrap
+from pathlib import Path
+from typing import Callable, Literal
+
+Shell = Literal["bash", "zsh"]
+
+_CLI_NAME: str = "siesta"
+"""Name of the CLI binary.
+
+All shell variable names, config-directory path components, and RC file
+comments are derived from this value.  Change it here to adapt the module for
+a different CLI tool.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Executable resolution
+# ---------------------------------------------------------------------------
+
+
+def resolve_cli_executable() -> str:
+    """Return the resolved absolute path to the active CLI executable.
+
+    Uses :func:`shutil.which` to locate the binary on ``PATH``, then resolves
+    symlinks so that the path is stable across different activation methods
+    (venv, pipx, conda, …).
+
+    Returns
+    -------
+    str
+        Absolute, symlink-resolved path if found; the bare CLI name string
+        if the binary is not on ``PATH`` (fallback that keeps callers
+        functional even when resolution fails).
+    """
+    resolved = shutil.which(_CLI_NAME)
+    return str(Path(resolved).expanduser().resolve()) if resolved else _CLI_NAME
+
+
+# ---------------------------------------------------------------------------
+# Stable exec ID (multi-install isolation)
+# ---------------------------------------------------------------------------
+
+
+def stable_exec_id(exec_path: str) -> str:
+    """Return a short, stable identifier for a CLI executable path.
+
+    The ID is the first 16 hex characters of the SHA-256 digest of the
+    resolved path string.  It is used as a filename component to isolate
+    completion artefacts belonging to different installations of the CLI
+    (e.g. separate virtual-environments) that share the same config directory.
+
+    Parameters
+    ----------
+    exec_path : str
+        Absolute, resolved path to the CLI binary.
+
+    Returns
+    -------
+    str
+        16-character lowercase hex string, unique per distinct path.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> stable_exec_id("/home/user/.venv/bin/siesta")
+        'a3f9c1d8e2b74501'  # illustrative; actual value depends on the path
+    """
+    return hashlib.sha256(exec_path.encode("utf-8")).hexdigest()[:16]
+
+
+# ---------------------------------------------------------------------------
+# Path computation (XDG-aware)
+# ---------------------------------------------------------------------------
+
+
+def managed_completion_paths(shell: Shell, exec_id: str) -> dict[str, Path]:
+    """Return the managed completion-related paths for ``shell`` and ``exec_id``.
+
+    The base directory respects ``$XDG_CONFIG_HOME`` when set, otherwise
+    defaults to ``~/.config``.
+
+    Parameters
+    ----------
+    shell : {'bash', 'zsh'}
+        Target shell.
+    exec_id : str
+        Stable identifier for the CLI executable (see :func:`stable_exec_id`).
+
+    Returns
+    -------
+    dict[str, Path]
+        Dictionary with the following keys:
+
+        ``base_dir``
+            ``<config_root>/<cli>/completions/<shell>/``
+        ``hook_file``
+            ``<base_dir>/hook.<shell>`` — sourced by the shell RC file.
+        ``static_file``
+            ``<base_dir>/static-<exec_id>.<shell>`` — cached completion
+            script.  Its mtime is kept in sync with the CLI executable for
+            staleness detection.
+    """
+    xdg_config_home = os.environ.get("XDG_CONFIG_HOME")
+    config_root = (
+        Path(xdg_config_home).expanduser()
+        if xdg_config_home
+        else Path.home() / ".config"
+    )
+    base_dir = config_root / _CLI_NAME / "completions" / shell
+    return {
+        "base_dir": base_dir,
+        "hook_file": base_dir / f"hook.{shell}",
+        "static_file": base_dir / f"static-{exec_id}.{shell}",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Shell hook rendering
+# ---------------------------------------------------------------------------
+
+
+def render_shell_hook(shell: Shell, *, base_dir: Path) -> str:
+    """Render a shell hook script that sources cached completions at startup.
+
+    The generated script:
+
+    * Sources the cached static completion file immediately at shell startup
+      (no Python spawned).
+    * Wraps the CLI command with a thin shell function that calls
+      ``_<cli>_maybe_refresh`` on the first invocation in each session.
+    * For zsh, additionally registers the completion function via ``compdef``.
+
+    Parameters
+    ----------
+    shell : {'bash', 'zsh'}
+        Target shell for the hook.
+    base_dir : Path
+        The base directory where managed completion files live
+        (``<config_root>/<cli>/completions/<shell>/``).
+
+    Returns
+    -------
+    str
+        Complete shell script text to be written to ``hook.<shell>``.
+    """
+    base_dir_str = str(base_dir)
+    if shell == "bash":
+        return textwrap.dedent(f"""\
+            # {_CLI_NAME} managed completion hook (bash)
+            # Generated by {_CLI_NAME} self tab-completions install
+            # shellcheck shell=bash
+
+            # Unset inherited guard so every new shell starts fresh.
+            unset _{_CLI_NAME.upper()}_COMPLETION_REFRESHED 2>/dev/null
+
+            _{_CLI_NAME}_completion_base_dir="{base_dir_str}"
+
+            # Resolve executable and exec_id once at startup (no Python spawned).
+            _{_CLI_NAME}_exec_path="$(command -v {_CLI_NAME} 2>/dev/null || true)"
+            _{_CLI_NAME}_exec_id=""
+            _{_CLI_NAME}_static_file=""
+            if [[ -n "${{_{_CLI_NAME}_exec_path}}" ]]; then
+              _{_CLI_NAME}_exec_id="$(printf '%s' "${{_{_CLI_NAME}_exec_path}}" | shasum -a 256 2>/dev/null | awk '{{print $1}}' | cut -c1-16)"
+              [[ -z "${{_{_CLI_NAME}_exec_id}}" ]] && _{_CLI_NAME}_exec_id="${{_{_CLI_NAME}_exec_path//\\//__}}"
+              _{_CLI_NAME}_static_file="${{_{_CLI_NAME}_completion_base_dir}}/static-${{_{_CLI_NAME}_exec_id}}.bash"
+              if [[ -f "${{_{_CLI_NAME}_static_file}}" ]]; then
+                # shellcheck source=/dev/null
+                source "${{_{_CLI_NAME}_static_file}}"
+              fi
+            fi
+
+            # On the first real invocation, regenerate completions if the executable is
+            # newer than the cached static script (i.e. the CLI was reinstalled or
+            # updated). Python is only spawned here, never at shell startup.
+            _{_CLI_NAME}_maybe_refresh() {{
+              if [[ -n "${{_{_CLI_NAME.upper()}_COMPLETION_REFRESHED:-}}" ]] || [[ -z "${{_{_CLI_NAME}_exec_id}}" ]]; then
+                return 0
+              fi
+              local tmp_file
+              if [[ ! -f "${{_{_CLI_NAME}_static_file}}" ]] || [[ "${{_{_CLI_NAME}_exec_path}}" -nt "${{_{_CLI_NAME}_static_file}}" ]]; then
+                tmp_file="${{_{_CLI_NAME}_static_file}}.tmp"
+                if command {_CLI_NAME} self tab-completions show --shell bash > "${{tmp_file}}" 2>/dev/null; then
+                  mv "${{tmp_file}}" "${{_{_CLI_NAME}_static_file}}"
+                  touch -r "${{_{_CLI_NAME}_exec_path}}" "${{_{_CLI_NAME}_static_file}}" 2>/dev/null || true
+                  # shellcheck source=/dev/null
+                  source "${{_{_CLI_NAME}_static_file}}"
+                else
+                  rm -f "${{tmp_file}}" 2>/dev/null || true
+                fi
+              fi
+              _{_CLI_NAME.upper()}_COMPLETION_REFRESHED=1
+            }}
+
+            {_CLI_NAME}() {{
+              _{_CLI_NAME}_maybe_refresh
+              command {_CLI_NAME} "$@"
+            }}
+            """)
+
+    return textwrap.dedent(f"""\
+        # {_CLI_NAME} managed completion hook (zsh)
+        # Generated by {_CLI_NAME} self tab-completions install
+
+        # Unset inherited guard so every new shell starts fresh.
+        unset _{_CLI_NAME.upper()}_COMPLETION_REFRESHED 2>/dev/null
+
+        _{_CLI_NAME}_completion_base_dir="{base_dir_str}"
+
+        # zsh: prefer whence -p for reliable absolute-path resolution; fall back to
+        # command -v and reject relative paths (e.g. from a local ./{_CLI_NAME}).
+        _{_CLI_NAME}_resolve_exec_path() {{
+          local p
+          p="$(whence -p {_CLI_NAME} 2>/dev/null || true)"
+          [[ -n "${{p}}" ]] && {{ printf '%s\n' "${{p}}"; return 0; }}
+          p="$(command -v {_CLI_NAME} 2>/dev/null || true)"
+          if [[ "${{p}}" = /* ]]; then
+            printf '%s\n' "${{p}}"
+          else
+            printf '%s\n' ""
+          fi
+        }}
+
+        _{_CLI_NAME}_exec_path="$(_{_CLI_NAME}_resolve_exec_path)"
+        _{_CLI_NAME}_exec_id=""
+        _{_CLI_NAME}_static_file=""
+        if [[ -n "${{_{_CLI_NAME}_exec_path}}" ]]; then
+          _{_CLI_NAME}_exec_id="$(printf '%s' "${{_{_CLI_NAME}_exec_path}}" | shasum -a 256 2>/dev/null | awk '{{print $1}}' | cut -c1-16)"
+          [[ -z "${{_{_CLI_NAME}_exec_id}}" ]] && _{_CLI_NAME}_exec_id="${{_{_CLI_NAME}_exec_path//\\//__}}"
+          _{_CLI_NAME}_static_file="${{_{_CLI_NAME}_completion_base_dir}}/static-${{_{_CLI_NAME}_exec_id}}.zsh"
+          [[ -f "${{_{_CLI_NAME}_static_file}}" ]] && source "${{_{_CLI_NAME}_static_file}}"
+        fi
+
+        # zsh re-resolves the exec path on every call so that switching virtual
+        # environments mid-session is handled correctly.
+        _{_CLI_NAME}_maybe_refresh() {{
+          local current_exec tmp_file
+          if [[ -n "${{_{_CLI_NAME.upper()}_COMPLETION_REFRESHED:-}}" ]]; then
+            return 0
+          fi
+
+          current_exec="$(_{_CLI_NAME}_resolve_exec_path)"
+          if [[ -z "${{current_exec}}" ]]; then
+            return 0
+          fi
+
+          if [[ "${{current_exec}}" != "${{_{_CLI_NAME}_exec_path}}" ]]; then
+            _{_CLI_NAME}_exec_path="${{current_exec}}"
+            _{_CLI_NAME}_exec_id="$(printf '%s' "${{_{_CLI_NAME}_exec_path}}" | shasum -a 256 2>/dev/null | awk '{{print $1}}' | cut -c1-16)"
+            [[ -z "${{_{_CLI_NAME}_exec_id}}" ]] && _{_CLI_NAME}_exec_id="${{_{_CLI_NAME}_exec_path//\\//__}}"
+            _{_CLI_NAME}_static_file="${{_{_CLI_NAME}_completion_base_dir}}/static-${{_{_CLI_NAME}_exec_id}}.zsh"
+          fi
+
+          if [[ ! -f "${{_{_CLI_NAME}_static_file}}" ]] || [[ "${{_{_CLI_NAME}_exec_path}}" -nt "${{_{_CLI_NAME}_static_file}}" ]]; then
+            tmp_file="${{_{_CLI_NAME}_static_file}}.tmp"
+            if command {_CLI_NAME} self tab-completions show --shell zsh > "${{tmp_file}}" 2>/dev/null; then
+              mv "${{tmp_file}}" "${{_{_CLI_NAME}_static_file}}"
+              touch -r "${{_{_CLI_NAME}_exec_path}}" "${{_{_CLI_NAME}_static_file}}" 2>/dev/null || true
+            else
+              rm -f "${{tmp_file}}" 2>/dev/null || true
+            fi
+          fi
+
+          [[ -f "${{_{_CLI_NAME}_static_file}}" ]] && source "${{_{_CLI_NAME}_static_file}}"
+          typeset -g _{_CLI_NAME.upper()}_COMPLETION_REFRESHED=1
+        }}
+
+        _{_CLI_NAME}_managed_completion() {{
+          _{_CLI_NAME}_maybe_refresh
+          if typeset -f _{_CLI_NAME} >/dev/null 2>&1; then
+            _{_CLI_NAME} "$@"
+          fi
+        }}
+
+        if (( $+functions[compdef] )); then
+          compdef _{_CLI_NAME}_managed_completion {_CLI_NAME} >/dev/null 2>&1
+        fi
+
+        {_CLI_NAME}() {{
+          _{_CLI_NAME}_maybe_refresh
+          command {_CLI_NAME} "$@"
+        }}
+        """)
+
+
+# ---------------------------------------------------------------------------
+# RC file management
+# ---------------------------------------------------------------------------
+
+
+def shell_rc_file(shell: Shell) -> Path:
+    """Return the primary startup RC file path for ``shell``.
+
+    Parameters
+    ----------
+    shell : {'bash', 'zsh'}
+        Target shell.
+
+    Returns
+    -------
+    Path
+        ``~/.bashrc`` for bash, ``~/.zshrc`` for zsh.
+    """
+    return Path.home() / (".bashrc" if shell == "bash" else ".zshrc")
+
+
+def ensure_rc_source_line(shell: Shell, hook_file: Path) -> None:
+    """Append a source line to the shell RC file (idempotent).
+
+    Creates the RC file if it does not exist.  If the source line is already
+    present the file is not modified, making repeated installs safe.
+
+    Parameters
+    ----------
+    shell : {'bash', 'zsh'}
+        Target shell (determines which RC file is used).
+    hook_file : Path
+        Absolute path to the managed hook file that should be sourced.
+    """
+    rc_file = shell_rc_file(shell)
+    rc_file.parent.mkdir(parents=True, exist_ok=True)
+    if not rc_file.exists():
+        rc_file.write_text("", encoding="utf-8")
+
+    source_line = f'[[ -f "{hook_file}" ]] && source "{hook_file}"'
+    content = rc_file.read_text(encoding="utf-8")
+    if source_line not in content:
+        with rc_file.open("a", encoding="utf-8") as fh:
+            if content and not content.endswith("\n"):
+                fh.write("\n")
+            fh.write(f"\n# {_CLI_NAME} managed completion\n{source_line}\n")
+
+
+def remove_rc_source_line(shell: Shell, hook_file: Path) -> None:
+    """Remove the managed source line from the shell RC file (idempotent).
+
+    Strips the ``# <cli> managed completion`` comment line and the ``source``
+    line added by :func:`ensure_rc_source_line`.  If neither line is found the
+    RC file is left untouched.  Does nothing if the RC file does not exist.
+
+    Parameters
+    ----------
+    shell : {'bash', 'zsh'}
+        Target shell (determines which RC file is used).
+    hook_file : Path
+        Absolute path to the hook file whose source line should be removed.
+    """
+    rc_file = shell_rc_file(shell)
+    if not rc_file.exists():
+        return
+
+    source_line = f'[[ -f "{hook_file}" ]] && source "{hook_file}"'
+    comment_line = f"# {_CLI_NAME} managed completion"
+    content = rc_file.read_text(encoding="utf-8")
+
+    if source_line not in content:
+        return
+
+    lines = content.splitlines(keepends=True)
+    filtered: list[str] = []
+    skip_next_blank = False
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.rstrip("\n").rstrip()
+        if stripped == comment_line or stripped == source_line:
+            # Also consume a leading blank line that we inserted before the block.
+            if filtered and filtered[-1].strip() == "":
+                filtered.pop()
+            skip_next_blank = True
+            i += 1
+            continue
+        if skip_next_blank and stripped == "":
+            skip_next_blank = False
+            i += 1
+            continue
+        skip_next_blank = False
+        filtered.append(line)
+        i += 1
+
+    rc_file.write_text("".join(filtered), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Shell detection and installation status
+# ---------------------------------------------------------------------------
+
+
+def detect_current_shell() -> Shell | None:
+    """Return the current user shell if it is a supported one.
+
+    Reads ``$SHELL`` and returns ``"bash"`` or ``"zsh"`` when the basename
+    matches, ``None`` otherwise (e.g. fish, unknown, or variable unset).
+
+    Returns
+    -------
+    Shell | None
+        ``"bash"``, ``"zsh"``, or ``None`` for unrecognised shells.
+    """
+    basename = os.path.basename(os.environ.get("SHELL", ""))
+    if basename in ("bash", "zsh"):
+        return basename  # type: ignore[return-value]
+    return None
+
+
+def is_completion_installed(shell: Shell) -> bool:
+    """Return whether managed completions are installed for ``shell``.
+
+    Checks for the presence of the managed hook file for the currently
+    resolved CLI executable.  Existence of the hook file is the definitive
+    indicator — if it was written, the install succeeded.  Staleness is
+    handled at shell startup by the hook itself.
+
+    Parameters
+    ----------
+    shell : {'bash', 'zsh'}
+        Shell to check.
+
+    Returns
+    -------
+    bool
+        ``True`` if the hook file exists for the current executable, ``False``
+        otherwise.
+    """
+    exec_path = resolve_cli_executable()
+    exec_id = stable_exec_id(exec_path)
+    paths = managed_completion_paths(shell=shell, exec_id=exec_id)
+    return paths["hook_file"].exists()
+
+
+# ---------------------------------------------------------------------------
+# Install / uninstall orchestration
+# ---------------------------------------------------------------------------
+
+
+def install_managed_completion(
+    shell: Shell,
+    generate_fn: Callable[[str], str],
+    *,
+    add_to_startup: bool,
+) -> Path:
+    """Install the managed completion hook and static script.
+
+    The static file's mtime is set to match the executable's mtime so the
+    shell hook can detect upgrades via a simple ``-nt`` comparison.
+
+    Parameters
+    ----------
+    shell : {'bash', 'zsh'}
+        Target shell.
+    generate_fn : Callable[[str], str]
+        Callable that accepts a ``shell`` keyword argument and returns the
+        raw completion script string.  Typically the CLI framework's
+        ``generate_completion`` method.  Passed explicitly to keep this module
+        free of CLI-framework imports.
+    add_to_startup : bool
+        When ``True``, append a source line for the hook file to the shell RC
+        file (``~/.bashrc`` / ``~/.zshrc``).
+
+    Returns
+    -------
+    Path
+        Path to the written hook file (``<base_dir>/hook.<shell>``).
+    """
+    exec_path = resolve_cli_executable()
+    exec_id = stable_exec_id(exec_path)
+    paths = managed_completion_paths(shell=shell, exec_id=exec_id)
+    paths["base_dir"].mkdir(parents=True, exist_ok=True)
+
+    completion_script = generate_fn(shell=shell)
+    paths["static_file"].write_text(completion_script, encoding="utf-8")
+
+    # Set the static file's mtime to match the executable so the hook knows
+    # completions are current.  If stat fails the hook will regenerate on
+    # first use.
+    try:
+        exec_stat = os.stat(exec_path)
+        os.utime(paths["static_file"], (exec_stat.st_atime, exec_stat.st_mtime))
+    except OSError:
+        pass
+
+    hook_content = render_shell_hook(shell=shell, base_dir=paths["base_dir"])
+    paths["hook_file"].write_text(hook_content, encoding="utf-8")
+
+    if add_to_startup:
+        ensure_rc_source_line(shell=shell, hook_file=paths["hook_file"])
+
+    return paths["hook_file"]
+
+
+def uninstall_managed_completion(shell: Shell) -> dict[str, list[Path]]:
+    """Remove managed completion files for the current executable and shell.
+
+    Deletes the hook file and the static completion script for the currently
+    resolved CLI executable.  Files belonging to *other* exec_ids (i.e. other
+    installations) are left untouched.  Also removes the RC source line added
+    during install.
+
+    Parameters
+    ----------
+    shell : {'bash', 'zsh'}
+        Target shell whose managed files should be removed.
+
+    Returns
+    -------
+    dict[str, list[Path]]
+        Dictionary with keys ``"removed"`` and ``"missing"``, each containing
+        a list of :class:`~pathlib.Path` objects that were successfully deleted
+        or were not found, respectively.
+    """
+    exec_path = resolve_cli_executable()
+    exec_id = stable_exec_id(exec_path)
+    paths = managed_completion_paths(shell=shell, exec_id=exec_id)
+
+    removed: list[Path] = []
+    missing: list[Path] = []
+
+    for key in ("hook_file", "static_file"):
+        target = paths[key]
+        if target.exists():
+            target.unlink()
+            removed.append(target)
+        else:
+            missing.append(target)
+
+    remove_rc_source_line(shell=shell, hook_file=paths["hook_file"])
+
+    return {"removed": removed, "missing": missing}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,7 +89,11 @@ def module_test_path(tmp_path_factory):
     current_dir = Path.cwd()
     try:
         os.chdir(tmp_path)  # Change to temp directory
-        app(["project", "quickstart", "--overwrite"])
+        try:
+            app(["project", "quickstart", "--overwrite"])
+        except SystemExit as e:
+            if e.code != 0:
+                raise
     finally:
         os.chdir(current_dir)  # Always restore original directory
     return tmp_path

--- a/tests/test_cli/test_build_docs.py
+++ b/tests/test_cli/test_build_docs.py
@@ -27,7 +27,11 @@ def module_test_path_no_docs(tmp_path_factory):
     current_dir = Path.cwd()
     try:
         os.chdir(tmp_path)  # Change to temp directory
-        app(["project", "quickstart", "--overwrite"])
+        try:
+            app(["project", "quickstart", "--overwrite"])
+        except SystemExit as e:
+            if e.code != 0:
+                raise
         shutil.rmtree(tmp_path / "docs")
     finally:
         os.chdir(current_dir)  # Always restore original directory
@@ -63,7 +67,10 @@ def test_build_docs_successful(module_test_path, monkeypatch, capture_output):
     monkeypatch.chdir(module_test_path)
 
     with capture_output() as output:
-        app(["docs", "build"])
+        try:
+            app(["docs", "build"])
+        except SystemExit as e:
+            assert e.code == 0
 
     # Verify success message
     assert a_in_b_str_no_space(
@@ -80,7 +87,10 @@ def test_build_docs_with_uv(module_test_path, monkeypatch, capture_output):
     Path("uv.lock").touch()
 
     with capture_output() as output:
-        app(["docs", "build"])
+        try:
+            app(["docs", "build"])
+        except SystemExit as e:
+            assert e.code == 0
 
     # Verify success message
     assert a_in_b_str_no_space(

--- a/tests/test_cli/test_init_docs.py
+++ b/tests/test_cli/test_init_docs.py
@@ -55,7 +55,10 @@ def test_init_docs_with_overwrite(
     (docs_dir / "marker.txt").write_text("original content")
 
     with capture_output() as output:
-        app(["docs", "init", "--overwrite"])
+        try:
+            app(["docs", "init", "--overwrite"])
+        except SystemExit as e:
+            assert e.code == 0
     assert "Failed to build the docs" not in output.getvalue()
 
     assert not (docs_dir / "marker.txt").exists()
@@ -69,7 +72,10 @@ def test_init_docs_package_discovery(
     monkeypatch.chdir(temp_project_with_git_and_remote)
 
     with capture_output() as output:
-        app(["docs", "init"])
+        try:
+            app(["docs", "init"])
+        except SystemExit as e:
+            assert e.code == 0
     assert "Failed to build the docs" not in output.getvalue()
 
     # Check conf.py contains discovered package
@@ -85,7 +91,10 @@ def test_init_docs_project_name(
     monkeypatch.chdir(temp_project_with_git_and_remote)
 
     with capture_output() as output:
-        app(["docs", "init"])
+        try:
+            app(["docs", "init"])
+        except SystemExit as e:
+            assert e.code == 0
     assert "Failed to build the docs" not in output.getvalue()
 
     # Check project name in conf.py
@@ -130,7 +139,10 @@ def test_init_docs_respects_no_deps(
 
     with capture_output() as output:
         # User specifies --no-deps, defaults should not override it
-        app(["docs", "init", "--no-deps"])
+        try:
+            app(["docs", "init", "--no-deps"])
+        except SystemExit as e:
+            assert e.code == 0
 
     output_text = output.getvalue()
     # deps should be False (user specified --no-deps)

--- a/tests/test_cli/test_open_docs.py
+++ b/tests/test_cli/test_open_docs.py
@@ -19,7 +19,10 @@ def test_open_docs(module_test_path, capture_output, platform, monkeypatch):
             if platform == "Windows":
                 with patch("siesta.cli.os.startfile", create=True) as mock_startfile:
                     with patch("siesta.cli.subprocess.call") as mock_call:
-                        app(["docs", "open"])
+                        try:
+                            app(["docs", "open"])
+                        except SystemExit as e:
+                            assert e.code == 0
                         mock_startfile.assert_called_once_with(
                             str(
                                 module_test_path
@@ -34,7 +37,10 @@ def test_open_docs(module_test_path, capture_output, platform, monkeypatch):
             else:
                 # For Darwin and Linux, only mock subprocess.call
                 with patch("siesta.cli.subprocess.call") as mock_call:
-                    app(["docs", "open"])
+                    try:
+                        app(["docs", "open"])
+                    except SystemExit as e:
+                        assert e.code == 0
                     if platform == "Darwin":
                         mock_call.assert_called_once_with(
                             (

--- a/tests/test_cli/test_quickstart_project.py
+++ b/tests/test_cli/test_quickstart_project.py
@@ -8,7 +8,10 @@ def test_quickstart_project(tmp_path_chdir, capture_output):
     """Test project quickstart command creates expected project structure."""
 
     with capture_output() as output:
-        app(["project", "quickstart"])
+        try:
+            app(["project", "quickstart"])
+        except SystemExit as e:
+            assert e.code == 0
 
     assert "Failed to build the docs" not in output.getvalue()
 
@@ -31,7 +34,10 @@ def test_quickstart_project_as_app(tmp_path_chdir, capture_output):
     """Test project quickstart --as-app creates app structure instead of library."""
 
     with capture_output() as output:
-        app(["project", "quickstart", "--as-app"])
+        try:
+            app(["project", "quickstart", "--as-app"])
+        except SystemExit as e:
+            assert e.code == 0
 
     assert "Failed to build the docs" not in output.getvalue()
     # Should not have src directory for app
@@ -44,7 +50,10 @@ def test_quickstart_project_as_pkg(tmp_path_chdir, capture_output):
     """Test project quickstart --as-pkg creates package structure in root directory."""
 
     with capture_output() as output:
-        app(["project", "quickstart", "--as-pkg"])
+        try:
+            app(["project", "quickstart", "--as-pkg"])
+        except SystemExit as e:
+            assert e.code == 0
 
     assert "Failed to build the docs" not in output.getvalue()
     assert (tmp_path_chdir / "src").exists()
@@ -56,7 +65,10 @@ def test_quickstart_respects_no_tests(tmp_path_chdir, capture_output):
 
     with capture_output() as output:
         # User specifies --no-tests, defaults should not override it
-        app(["project", "quickstart", "--no-tests"])
+        try:
+            app(["project", "quickstart", "--no-tests"])
+        except SystemExit as e:
+            assert e.code == 0
 
     output_text = output.getvalue()
     assert "Failed to build the docs" not in output_text
@@ -81,7 +93,10 @@ def test_quickstart_respects_no_actions(tmp_path_chdir, capture_output):
 
     with capture_output() as output:
         # User specifies --no-actions, defaults should not override it
-        app(["project", "quickstart", "--no-actions"])
+        try:
+            app(["project", "quickstart", "--no-actions"])
+        except SystemExit as e:
+            assert e.code == 0
 
     assert "Failed to build the docs" not in output.getvalue()
 
@@ -98,14 +113,17 @@ def test_quickstart_respects_no_tests_and_no_actions(tmp_path_chdir, capture_out
 
     with capture_output() as output:
         # User specifies both --no-tests and --no-actions
-        app(
-            [
-                "project",
-                "quickstart",
-                "--no-tests",
-                "--no-actions",
-            ]
-        )
+        try:
+            app(
+                [
+                    "project",
+                    "quickstart",
+                    "--no-tests",
+                    "--no-actions",
+                ]
+            )
+        except SystemExit as e:
+            assert e.code == 0
 
     assert "Failed to build the docs" not in output.getvalue()
 

--- a/tests/test_cli/test_setup_tests.py
+++ b/tests/test_cli/test_setup_tests.py
@@ -28,7 +28,10 @@ def existing_uv_project(tmp_path):
 def test_setup_tests_creates_tests_directory(existing_uv_project, capture_output):
     """Test that setup-tests creates the tests directory with example test."""
     with capture_output() as output:
-        app(["project", "setup-tests"])
+        try:
+            app(["project", "setup-tests"])
+        except SystemExit as e:
+            assert e.code == 0
 
     output_text = output.getvalue()
     assert "Tests infra written" in output_text
@@ -48,7 +51,10 @@ def test_setup_tests_creates_tests_directory(existing_uv_project, capture_output
 def test_setup_tests_creates_github_actions(existing_uv_project, capture_output):
     """Test that setup-tests creates GitHub Actions workflow."""
     with capture_output():
-        app(["project", "setup-tests"])
+        try:
+            app(["project", "setup-tests"])
+        except SystemExit as e:
+            assert e.code == 0
 
     # Check GitHub Actions directory exists
     assert (existing_uv_project / ".github").exists()
@@ -61,16 +67,19 @@ def test_setup_tests_without_actions(existing_uv_project, capture_output):
     with capture_output() as output:
         # Use --deps to install deps but --no-actions to skip actions
         # Pass project name and -i (interactive) to test explicit flag handling
-        app(
-            [
-                "project",
-                "setup-tests",
-                "--project-name=existing_project",
-                "--deps",
-                "--no-actions",
-                "-i",
-            ]
-        )
+        try:
+            app(
+                [
+                    "project",
+                    "setup-tests",
+                    "--project-name=existing_project",
+                    "--deps",
+                    "--no-actions",
+                    "-i",
+                ]
+            )
+        except SystemExit as e:
+            assert e.code == 0
 
     output_text = output.getvalue()
     assert "Tests infra written" in output_text
@@ -91,7 +100,10 @@ def test_setup_tests_skips_existing_tests_directory(
     (existing_uv_project / "tests" / "existing_test.py").write_text("# existing test")
 
     with capture_output() as output:
-        app(["project", "setup-tests"])
+        try:
+            app(["project", "setup-tests"])
+        except SystemExit as e:
+            assert e.code == 0
 
     output_text = output.getvalue()
     assert "Tests directory already exists" in output_text
@@ -106,7 +118,10 @@ def test_setup_tests_respects_no_actions(existing_uv_project, capture_output):
     """Test that user flags take precedence (--no-actions)."""
     with capture_output() as output:
         # User specifies --no-actions, defaults should not override it
-        app(["project", "setup-tests", "--no-actions"])
+        try:
+            app(["project", "setup-tests", "--no-actions"])
+        except SystemExit as e:
+            assert e.code == 0
 
     output_text = output.getvalue()
     assert "Tests infra written" in output_text
@@ -124,7 +139,10 @@ def test_setup_tests_respects_no_deps(existing_uv_project, capture_output):
     """Test that user flags take precedence (--no-deps)."""
     with capture_output() as output:
         # User specifies --no-deps, defaults should not override it
-        app(["project", "setup-tests", "--no-deps"])
+        try:
+            app(["project", "setup-tests", "--no-deps"])
+        except SystemExit as e:
+            assert e.code == 0
 
     output_text = output.getvalue()
     assert "Tests infra written" in output_text
@@ -145,16 +163,19 @@ def test_setup_tests_interactive_flag(existing_uv_project, capture_output):
     with capture_output() as output:
         # Use -i with explicit flags to avoid prompts in test
         # -i should override default behavior (which would auto-accept)
-        app(
-            [
-                "project",
-                "setup-tests",
-                "-i",  # interactive mode
-                "--project-name=existing_project",  # explicitly set to avoid prompt
-                "--deps",  # explicitly set to avoid prompt
-                "--no-actions",  # explicitly set to avoid prompt
-            ]
-        )
+        try:
+            app(
+                [
+                    "project",
+                    "setup-tests",
+                    "-i",  # interactive mode
+                    "--project-name=existing_project",  # explicitly set to avoid prompt
+                    "--deps",  # explicitly set to avoid prompt
+                    "--no-actions",  # explicitly set to avoid prompt
+                ]
+            )
+        except SystemExit as e:
+            assert e.code == 0
 
     output_text = output.getvalue()
     assert "Tests infra written" in output_text

--- a/tests/test_cli/test_show_github_pat.py
+++ b/tests/test_cli/test_show_github_pat.py
@@ -7,7 +7,10 @@ from siesta.cli import app
 def test_show_github_pat_masked(capture_output):
     """Test that show-github-pat displays a masked token by default."""
     with capture_output() as output:
-        app(["self", "show-github-pat"])
+        try:
+            app(["self", "show-github-pat"])
+        except SystemExit as e:
+            assert e.code == 0
 
     output_text = output.getvalue()
     assert "fake-github-" in output_text
@@ -19,7 +22,10 @@ def test_show_github_pat_masked(capture_output):
 def test_show_github_pat_full(capture_output):
     """Test that show-github-pat --full displays the full token with a warning."""
     with capture_output() as output:
-        app(["self", "show-github-pat", "--full"])
+        try:
+            app(["self", "show-github-pat", "--full"])
+        except SystemExit as e:
+            assert e.code == 0
 
     output_text = output.getvalue()
     assert "fake-github-pat-for-testing" in output_text
@@ -33,7 +39,10 @@ def test_show_github_pat_none(capture_output):
         patch("siesta.cli.get_user_pat", return_value=None),
     ):
         with capture_output() as output:
-            app(["self", "show-github-pat"])
+            try:
+                app(["self", "show-github-pat"])
+            except SystemExit as e:
+                assert e.code == 0
 
     output_text = output.getvalue()
     assert "No GitHub PAT found" in output_text

--- a/tests/test_cli/test_tab_completions.py
+++ b/tests/test_cli/test_tab_completions.py
@@ -39,6 +39,7 @@ import pytest
 from siesta.cli import app
 from siesta.completions import (
     _CLI_NAME,
+    _shell_quote,
     detect_current_shell,
     is_completion_installed,
     managed_completion_paths,
@@ -217,6 +218,18 @@ class TestHelpers:
             == tmp_path / ".config" / _CLI_NAME / "completions" / "zsh"
         )
 
+    def test_managed_completion_paths_empty_xdg_treated_as_unset(
+        self, monkeypatch, tmp_path
+    ):
+        """Empty ``$XDG_CONFIG_HOME`` falls back to ``~/.config`` per XDG spec."""
+        monkeypatch.setenv("XDG_CONFIG_HOME", "")
+        monkeypatch.setenv("HOME", str(tmp_path))
+        paths = managed_completion_paths("bash", "abcd1234abcd1234")
+        assert (
+            paths["base_dir"]
+            == tmp_path / ".config" / _CLI_NAME / "completions" / "bash"
+        )
+
     def test_managed_completion_paths_keys(self):
         paths = managed_completion_paths("bash", "1234567890abcdef")
         assert set(paths.keys()) == {"base_dir", "hook_file", "static_file"}
@@ -232,6 +245,21 @@ class TestHelpers:
 
     def test_shell_rc_file_zsh(self):
         assert shell_rc_file("zsh").name == ".zshrc"
+
+    def test_shell_quote_simple_path(self):
+        assert _shell_quote("/usr/bin/siesta") == "'/usr/bin/siesta'"
+
+    def test_shell_quote_path_with_spaces(self):
+        assert _shell_quote("/my path/bin") == "'/my path/bin'"
+
+    def test_shell_quote_path_with_dollar(self):
+        assert _shell_quote("/home/$USER/bin") == "'/home/$USER/bin'"
+
+    def test_shell_quote_path_with_single_quote(self):
+        assert _shell_quote("/it's/a/path") == "'/it'\\''s/a/path'"
+
+    def test_shell_quote_accepts_path_object(self):
+        assert _shell_quote(Path("/usr/bin")) == "'/usr/bin'"
 
 
 # ---------------------------------------------------------------------------
@@ -279,6 +307,26 @@ class TestRenderHook:
     def test_bash_hook_does_not_contain_compdef(self, tmp_path):
         hook = render_shell_hook("bash", base_dir=tmp_path)
         assert "compdef" not in hook
+
+    def test_bash_hook_single_quotes_base_dir(self, tmp_path):
+        hook = render_shell_hook("bash", base_dir=tmp_path)
+        assert f"_{_CLI_NAME}_completion_base_dir='{tmp_path}'" in hook
+
+    def test_zsh_hook_single_quotes_base_dir(self, tmp_path):
+        hook = render_shell_hook("zsh", base_dir=tmp_path)
+        assert f"_{_CLI_NAME}_completion_base_dir='{tmp_path}'" in hook
+
+    def test_bash_hook_uses_portable_sha256(self, tmp_path):
+        hook = render_shell_hook("bash", base_dir=tmp_path)
+        assert f"_{_CLI_NAME}_sha256_16" in hook
+        assert "sha256sum" in hook
+        assert "shasum" in hook
+
+    def test_zsh_hook_uses_portable_sha256(self, tmp_path):
+        hook = render_shell_hook("zsh", base_dir=tmp_path)
+        assert f"_{_CLI_NAME}_sha256_16" in hook
+        assert "sha256sum" in hook
+        assert "shasum" in hook
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli/test_tab_completions.py
+++ b/tests/test_cli/test_tab_completions.py
@@ -161,9 +161,7 @@ def isolated_home(tmp_path, monkeypatch):
 @pytest.fixture()
 def mock_which():
     """Patch ``shutil.which`` in the completions module to return a fake path."""
-    with patch(
-        "siesta.completions.shutil.which", return_value=FAKE_EXEC
-    ) as m:
+    with patch("siesta.completions.shutil.which", return_value=FAKE_EXEC) as m:
         yield m
 
 
@@ -908,8 +906,7 @@ class TestHelpEpilogue:
         original = app.help_epilogue
         try:
             app.help_epilogue = (
-                "Tip: enable tab completions with "
-                "`siesta self tab-completions install`"
+                "Tip: enable tab completions with `siesta self tab-completions install`"
             )
             with pytest.raises(SystemExit):
                 app(["--help"], exit_on_error=False)
@@ -936,8 +933,7 @@ class TestHelpEpilogue:
         original = app.help_epilogue
         try:
             app.help_epilogue = (
-                "Tip: enable tab completions with "
-                "`siesta self tab-completions install`"
+                "Tip: enable tab completions with `siesta self tab-completions install`"
             )
             with pytest.raises(SystemExit):
                 app(["self", "--help"], exit_on_error=False)

--- a/tests/test_cli/test_tab_completions.py
+++ b/tests/test_cli/test_tab_completions.py
@@ -1,0 +1,947 @@
+# Copyright 2025 Entalpic
+"""
+Unit tests for :mod:`siesta.completions`.
+
+Tests are organised into classes that mirror the public API of the module:
+
+* ``TestHelpers``               — pure utility functions (exec resolution, ID
+                                  hashing, path computation).
+* ``TestRenderHook``            — shell hook script content for bash and zsh.
+* ``TestRcManagement``          — RC file source-line insertion and removal.
+* ``TestInstall``               — end-to-end install flow for bash and zsh via
+                                  ``self tab-completions install``.
+* ``TestRefreshBehavior``       — runtime hook refresh (bash and zsh) when
+                                  executable mtime is newer than cached static
+                                  completion file.
+* ``TestUninstall``             — end-to-end uninstall flow and edge cases via
+                                  ``self tab-completions uninstall``.
+* ``TestShow``                  — print-to-stdout mode via
+                                  ``self tab-completions show``.
+* ``TestWhere``                 — path display via ``self tab-completions where``.
+* ``TestDetectCurrentShell``    — shell detection from ``$SHELL``.
+* ``TestIsCompletionInstalled`` — hook-file presence check.
+* ``TestShellDefaulting``       — automatic shell detection and error when
+                                  shell cannot be detected.
+* ``TestHelpEpilogue``          — completion hint appears in help output.
+"""
+
+import os
+import shlex
+import shutil
+import subprocess
+from pathlib import Path
+from textwrap import dedent
+from unittest.mock import patch
+
+import cyclopts
+import pytest
+
+from siesta.cli import app
+from siesta.completions import (
+    _CLI_NAME,
+    detect_current_shell,
+    is_completion_installed,
+    managed_completion_paths,
+    remove_rc_source_line,
+    render_shell_hook,
+    resolve_cli_executable,
+    shell_rc_file,
+    stable_exec_id,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+FAKE_EXEC = "/tmp/bin/siesta"
+
+
+def _fake_siesta_refresh_stub(*, completion_shell: str) -> str:
+    """Executable placed on PATH; handles ``self tab-completions show --shell <shell>``.
+
+    Uses the same interpreter as ``completion_shell`` so the stub matches the
+    shell family under test (bash vs zsh).
+    """
+    return dedent(
+        f"""\
+        #!/usr/bin/env {completion_shell}
+        if [[ "${{1:-}}" == "self" && "${{2:-}}" == "tab-completions" && "${{3:-}}" == "show" && "${{4:-}}" == "--shell" && "${{5:-}}" == "{completion_shell}" ]]; then
+          printf '# Refreshed completion\\n'
+          printf 'show\\n' >> "${{SIESTA_SHOW_LOG}}"
+          exit 0
+        fi
+        exit 0
+        """
+    )
+
+
+def _assert_managed_hook_refreshes_when_binary_newer(
+    isolated_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    completion_shell: str,
+) -> None:
+    """Drive install + hook: static file is regenerated when binary mtime is newer."""
+    if completion_shell == "zsh" and shutil.which("zsh") is None:
+        pytest.skip("zsh not found on PATH")
+
+    fake_bin_dir = isolated_home / "bin"
+    fake_bin_dir.mkdir(parents=True, exist_ok=True)
+    fake_exec = fake_bin_dir / _CLI_NAME
+    show_log = isolated_home / "show-calls.log"
+    fake_exec.write_text(
+        _fake_siesta_refresh_stub(completion_shell=completion_shell),
+        encoding="utf-8",
+    )
+    fake_exec.chmod(0o755)
+
+    monkeypatch.setenv("PATH", f"{fake_bin_dir}:{os.environ.get('PATH', '')}")
+
+    with patch.object(
+        cyclopts.App,
+        "generate_completion",
+        return_value="# Initial completion\n",
+    ):
+        with pytest.raises(SystemExit):
+            app(
+                [
+                    "self",
+                    "tab-completions",
+                    "install",
+                    "--shell",
+                    completion_shell,
+                    "--no-add-to-startup",
+                ],
+                exit_on_error=False,
+            )
+
+    exec_id = stable_exec_id(str(fake_exec.resolve()))
+    paths = managed_completion_paths(completion_shell, exec_id)
+    assert paths["static_file"].read_text(encoding="utf-8") == "# Initial completion\n"
+
+    static_mtime = paths["static_file"].stat().st_mtime
+    os.utime(fake_exec, (static_mtime + 5, static_mtime + 5))
+
+    env = os.environ.copy()
+    env["SIESTA_SHOW_LOG"] = str(show_log)
+    hook_q = shlex.quote(str(paths["hook_file"]))
+
+    if completion_shell == "bash":
+        subprocess.run(
+            ["bash", "-lc", f"source {hook_q} && siesta ping"],
+            check=True,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+    else:
+        subprocess.run(
+            ["zsh", "-fc", f". {hook_q} && siesta ping"],
+            check=True,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+
+    assert show_log.read_text(encoding="utf-8") == "show\n"
+    assert (
+        paths["static_file"].read_text(encoding="utf-8") == "# Refreshed completion\n"
+    )
+    assert int(paths["static_file"].stat().st_mtime) == int(fake_exec.stat().st_mtime)
+
+
+@pytest.fixture()
+def isolated_home(tmp_path, monkeypatch):
+    """Redirect HOME and XDG_CONFIG_HOME to ``tmp_path`` for full isolation."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+    return tmp_path
+
+
+@pytest.fixture()
+def mock_which():
+    """Patch ``shutil.which`` in the completions module to return a fake path."""
+    with patch(
+        "siesta.completions.shutil.which", return_value=FAKE_EXEC
+    ) as m:
+        yield m
+
+
+@pytest.fixture()
+def mock_generate_completion():
+    """Patch ``cyclopts.App.generate_completion`` to return a lightweight stub."""
+    with patch.object(
+        cyclopts.App,
+        "generate_completion",
+        return_value="# Stub completion\n",
+    ) as m:
+        yield m
+
+
+# ---------------------------------------------------------------------------
+# TestHelpers
+# ---------------------------------------------------------------------------
+
+
+class TestHelpers:
+    def test_resolve_executable_uses_which(self, mock_which):
+        result = resolve_cli_executable()
+        assert result == str(Path(FAKE_EXEC).expanduser().resolve())
+
+    def test_resolve_executable_fallback_when_not_found(self):
+        with patch("siesta.completions.shutil.which", return_value=None):
+            result = resolve_cli_executable()
+        assert result == _CLI_NAME
+
+    def test_stable_exec_id_is_16_chars(self):
+        assert len(stable_exec_id("/some/path/siesta")) == 16
+
+    def test_stable_exec_id_differs_for_two_paths(self):
+        assert stable_exec_id("/tmp/a/siesta") != stable_exec_id("/tmp/b/siesta")
+
+    def test_stable_exec_id_is_deterministic(self):
+        path = "/home/user/.venv/bin/siesta"
+        assert stable_exec_id(path) == stable_exec_id(path)
+
+    def test_managed_completion_paths_uses_xdg(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+        paths = managed_completion_paths("bash", "abcd1234abcd1234")
+        assert (
+            paths["base_dir"] == tmp_path / "xdg" / _CLI_NAME / "completions" / "bash"
+        )
+
+    def test_managed_completion_paths_without_xdg(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        paths = managed_completion_paths("zsh", "abcd1234abcd1234")
+        assert (
+            paths["base_dir"]
+            == tmp_path / ".config" / _CLI_NAME / "completions" / "zsh"
+        )
+
+    def test_managed_completion_paths_keys(self):
+        paths = managed_completion_paths("bash", "1234567890abcdef")
+        assert set(paths.keys()) == {"base_dir", "hook_file", "static_file"}
+
+    def test_managed_completion_paths_filenames(self):
+        exec_id = "1234567890abcdef"
+        paths = managed_completion_paths("zsh", exec_id)
+        assert paths["hook_file"].name == "hook.zsh"
+        assert paths["static_file"].name == f"static-{exec_id}.zsh"
+
+    def test_shell_rc_file_bash(self):
+        assert shell_rc_file("bash").name == ".bashrc"
+
+    def test_shell_rc_file_zsh(self):
+        assert shell_rc_file("zsh").name == ".zshrc"
+
+
+# ---------------------------------------------------------------------------
+# TestRenderHook
+# ---------------------------------------------------------------------------
+
+
+class TestRenderHook:
+    def test_bash_hook_contains_maybe_refresh(self, tmp_path):
+        hook = render_shell_hook("bash", base_dir=tmp_path)
+        assert f"_{_CLI_NAME}_maybe_refresh" in hook
+
+    def test_bash_hook_contains_regenerate_command(self, tmp_path):
+        hook = render_shell_hook("bash", base_dir=tmp_path)
+        assert f"command {_CLI_NAME} self tab-completions show --shell bash" in hook
+
+    def test_bash_hook_contains_base_dir(self, tmp_path):
+        hook = render_shell_hook("bash", base_dir=tmp_path)
+        assert str(tmp_path) in hook
+
+    def test_bash_hook_contains_shellcheck_directive(self, tmp_path):
+        hook = render_shell_hook("bash", base_dir=tmp_path)
+        assert "# shellcheck shell=bash" in hook
+
+    def test_zsh_hook_contains_compdef(self, tmp_path):
+        hook = render_shell_hook("zsh", base_dir=tmp_path)
+        assert "compdef" in hook
+
+    def test_zsh_hook_contains_resolve_function(self, tmp_path):
+        hook = render_shell_hook("zsh", base_dir=tmp_path)
+        assert f"_{_CLI_NAME}_resolve_exec_path" in hook
+
+    def test_zsh_hook_contains_regenerate_command(self, tmp_path):
+        hook = render_shell_hook("zsh", base_dir=tmp_path)
+        assert f"command {_CLI_NAME} self tab-completions show --shell zsh" in hook
+
+    def test_zsh_hook_contains_base_dir(self, tmp_path):
+        hook = render_shell_hook("zsh", base_dir=tmp_path)
+        assert str(tmp_path) in hook
+
+    def test_zsh_hook_contains_whence(self, tmp_path):
+        hook = render_shell_hook("zsh", base_dir=tmp_path)
+        assert "whence -p" in hook
+
+    def test_bash_hook_does_not_contain_compdef(self, tmp_path):
+        hook = render_shell_hook("bash", base_dir=tmp_path)
+        assert "compdef" not in hook
+
+
+# ---------------------------------------------------------------------------
+# TestRcManagement
+# ---------------------------------------------------------------------------
+
+
+class TestRcManagement:
+    def test_ensure_creates_rc_if_absent(self, isolated_home):
+        from siesta.completions import ensure_rc_source_line
+
+        hook = (
+            isolated_home / ".config" / _CLI_NAME / "completions" / "bash" / "hook.bash"
+        )
+        ensure_rc_source_line("bash", hook)
+        assert (isolated_home / ".bashrc").exists()
+
+    def test_ensure_adds_source_line(self, isolated_home):
+        from siesta.completions import ensure_rc_source_line
+
+        hook = Path("/some/hook.bash")
+        ensure_rc_source_line("bash", hook)
+        content = (isolated_home / ".bashrc").read_text()
+        assert str(hook) in content
+
+    def test_ensure_is_idempotent(self, isolated_home):
+        from siesta.completions import ensure_rc_source_line
+
+        hook = Path("/some/hook.bash")
+        ensure_rc_source_line("bash", hook)
+        ensure_rc_source_line("bash", hook)
+        content = (isolated_home / ".bashrc").read_text()
+        assert content.count(f"{_CLI_NAME} managed completion") == 1
+
+    def test_remove_rc_source_line_strips_comment_and_source(self, isolated_home):
+        from siesta.completions import ensure_rc_source_line
+
+        hook = Path("/some/hook.bash")
+        ensure_rc_source_line("bash", hook)
+        remove_rc_source_line("bash", hook)
+        content = (isolated_home / ".bashrc").read_text()
+        assert str(hook) not in content
+        assert f"{_CLI_NAME} managed completion" not in content
+
+    def test_remove_rc_source_line_is_idempotent(self, isolated_home):
+        from siesta.completions import ensure_rc_source_line
+
+        hook = Path("/some/hook.bash")
+        ensure_rc_source_line("bash", hook)
+        remove_rc_source_line("bash", hook)
+        remove_rc_source_line("bash", hook)  # second call must not raise
+        content = (isolated_home / ".bashrc").read_text()
+        assert f"{_CLI_NAME} managed completion" not in content
+
+    def test_remove_noop_when_rc_missing(self, isolated_home):
+        hook = Path("/nonexistent/hook.bash")
+        remove_rc_source_line("bash", hook)  # must not raise
+
+    def test_remove_noop_when_line_absent(self, isolated_home):
+        rc = isolated_home / ".bashrc"
+        rc.write_text("# pre-existing content\n")
+        hook = Path("/some/hook.bash")
+        remove_rc_source_line("bash", hook)
+        assert rc.read_text() == "# pre-existing content\n"
+
+
+# ---------------------------------------------------------------------------
+# TestInstall — CLI round-trip via `self tab-completions install`
+# ---------------------------------------------------------------------------
+
+
+class TestInstall:
+    def test_install_bash_creates_all_files(
+        self, isolated_home, mock_which, mock_generate_completion, capsys
+    ):
+        """Install mode writes hook and static files for bash."""
+        with pytest.raises(SystemExit):
+            app(
+                ["self", "tab-completions", "install", "--shell", "bash"],
+                exit_on_error=False,
+            )
+
+        base_dir = isolated_home / "config" / _CLI_NAME / "completions" / "bash"
+        assert (base_dir / "hook.bash").exists()
+        assert len(list(base_dir.glob("static-*.bash"))) == 1
+
+    def test_install_bash_hook_content(
+        self, isolated_home, mock_which, mock_generate_completion
+    ):
+        with pytest.raises(SystemExit):
+            app(
+                ["self", "tab-completions", "install", "--shell", "bash"],
+                exit_on_error=False,
+            )
+
+        base_dir = isolated_home / "config" / _CLI_NAME / "completions" / "bash"
+        hook_text = (base_dir / "hook.bash").read_text()
+        assert f"_{_CLI_NAME}_maybe_refresh" in hook_text
+        assert (
+            f"command {_CLI_NAME} self tab-completions show --shell bash" in hook_text
+        )
+
+    def test_install_bash_adds_rc_line(
+        self, isolated_home, mock_which, mock_generate_completion
+    ):
+        with pytest.raises(SystemExit):
+            app(
+                ["self", "tab-completions", "install", "--shell", "bash"],
+                exit_on_error=False,
+            )
+
+        rc_content = (isolated_home / ".bashrc").read_text()
+        hook_path = (
+            isolated_home / "config" / _CLI_NAME / "completions" / "bash" / "hook.bash"
+        )
+        assert str(hook_path) in rc_content
+
+    def test_install_bash_rc_idempotent(
+        self, isolated_home, mock_which, mock_generate_completion
+    ):
+        for _ in range(2):
+            with pytest.raises(SystemExit):
+                app(
+                    ["self", "tab-completions", "install", "--shell", "bash"],
+                    exit_on_error=False,
+                )
+        rc = (isolated_home / ".bashrc").read_text()
+        assert rc.count(f"{_CLI_NAME} managed completion") == 1
+
+    def test_install_bash_output_message(
+        self, isolated_home, mock_which, mock_generate_completion, capsys
+    ):
+        with pytest.raises(SystemExit):
+            app(
+                ["self", "tab-completions", "install", "--shell", "bash"],
+                exit_on_error=False,
+            )
+        out = capsys.readouterr().out
+        assert "Managed completion installed to" in out
+        assert "hook.bash" in out
+
+    def test_install_bash_prints_restart_hint(
+        self, isolated_home, mock_which, mock_generate_completion, capsys
+    ):
+        with pytest.raises(SystemExit):
+            app(
+                ["self", "tab-completions", "install", "--shell", "bash"],
+                exit_on_error=False,
+            )
+        out = capsys.readouterr().out
+        assert "Restart your shell" in out or ".bashrc" in out
+
+    def test_install_zsh_creates_all_files(
+        self, isolated_home, mock_which, mock_generate_completion
+    ):
+        """Install mode writes hook and static files for zsh."""
+        with pytest.raises(SystemExit):
+            app(
+                ["self", "tab-completions", "install", "--shell", "zsh"],
+                exit_on_error=False,
+            )
+
+        base_dir = isolated_home / "config" / _CLI_NAME / "completions" / "zsh"
+        assert (base_dir / "hook.zsh").exists()
+        assert len(list(base_dir.glob("static-*.zsh"))) == 1
+
+    def test_install_zsh_hook_content(
+        self, isolated_home, mock_which, mock_generate_completion
+    ):
+        with pytest.raises(SystemExit):
+            app(
+                ["self", "tab-completions", "install", "--shell", "zsh"],
+                exit_on_error=False,
+            )
+
+        base_dir = isolated_home / "config" / _CLI_NAME / "completions" / "zsh"
+        hook_text = (base_dir / "hook.zsh").read_text()
+        assert "compdef" in hook_text
+        assert f"command {_CLI_NAME} self tab-completions show --shell zsh" in hook_text
+
+    def test_install_zsh_adds_rc_line(
+        self, isolated_home, mock_which, mock_generate_completion
+    ):
+        with pytest.raises(SystemExit):
+            app(
+                ["self", "tab-completions", "install", "--shell", "zsh"],
+                exit_on_error=False,
+            )
+
+        rc_content = (isolated_home / ".zshrc").read_text()
+        hook_path = (
+            isolated_home / "config" / _CLI_NAME / "completions" / "zsh" / "hook.zsh"
+        )
+        assert str(hook_path) in rc_content
+
+    def test_install_no_add_to_startup_skips_rc(
+        self, isolated_home, mock_which, mock_generate_completion
+    ):
+        """``--no-add-to-startup`` must not touch the shell RC file."""
+        with pytest.raises(SystemExit):
+            app(
+                [
+                    "self",
+                    "tab-completions",
+                    "install",
+                    "--shell",
+                    "zsh",
+                    "--no-add-to-startup",
+                ],
+                exit_on_error=False,
+            )
+        assert not (isolated_home / ".zshrc").exists()
+
+
+# ---------------------------------------------------------------------------
+# TestRefreshBehavior — runtime hook refresh behavior
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshBehavior:
+    def test_bash_hook_regenerates_when_exec_is_newer(self, isolated_home, monkeypatch):
+        """Bash hook regenerates static completions when executable mtime is newer."""
+        _assert_managed_hook_refreshes_when_binary_newer(
+            isolated_home, monkeypatch, completion_shell="bash"
+        )
+
+    def test_zsh_hook_regenerates_when_exec_is_newer(self, isolated_home, monkeypatch):
+        """Zsh hook regenerates static completions when executable mtime is newer."""
+        _assert_managed_hook_refreshes_when_binary_newer(
+            isolated_home, monkeypatch, completion_shell="zsh"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestUninstall — CLI round-trip via `self tab-completions uninstall`
+# ---------------------------------------------------------------------------
+
+
+class TestUninstall:
+    def _do_install(self, shell, isolated_home, mock_which, mock_generate_completion):
+        with pytest.raises(SystemExit):
+            app(
+                ["self", "tab-completions", "install", "--shell", shell],
+                exit_on_error=False,
+            )
+
+    def test_uninstall_removes_managed_files(
+        self, isolated_home, mock_which, mock_generate_completion
+    ):
+        self._do_install("bash", isolated_home, mock_which, mock_generate_completion)
+        base_dir = isolated_home / "config" / _CLI_NAME / "completions" / "bash"
+        assert (base_dir / "hook.bash").exists()
+
+        with pytest.raises(SystemExit):
+            app(
+                ["self", "tab-completions", "uninstall", "--shell", "bash"],
+                exit_on_error=False,
+            )
+
+        assert not (base_dir / "hook.bash").exists()
+        assert list(base_dir.glob("static-*.bash")) == []
+
+    def test_uninstall_removes_rc_source_line(
+        self, isolated_home, mock_which, mock_generate_completion
+    ):
+        self._do_install("bash", isolated_home, mock_which, mock_generate_completion)
+        rc = isolated_home / ".bashrc"
+        assert f"{_CLI_NAME} managed completion" in rc.read_text()
+
+        with pytest.raises(SystemExit):
+            app(
+                ["self", "tab-completions", "uninstall", "--shell", "bash"],
+                exit_on_error=False,
+            )
+
+        assert f"{_CLI_NAME} managed completion" not in rc.read_text()
+
+    def test_uninstall_noop_when_not_installed(self, isolated_home, mock_which, capsys):
+        """Uninstall must not raise when no managed files exist."""
+        with pytest.raises(SystemExit):
+            app(
+                ["self", "tab-completions", "uninstall", "--shell", "zsh"],
+                exit_on_error=False,
+            )
+        out = capsys.readouterr().out
+        assert "Not found" in out or "Nothing" in out
+
+    def test_uninstall_does_not_touch_other_exec_files(
+        self, isolated_home, mock_generate_completion
+    ):
+        """Files for a *different* exec_id must survive uninstall."""
+        exec_a = "/tmp/venv_a/bin/siesta"
+        exec_b = "/tmp/venv_b/bin/siesta"
+
+        with patch("siesta.completions.shutil.which", return_value=exec_a):
+            with pytest.raises(SystemExit):
+                app(
+                    [
+                        "self",
+                        "tab-completions",
+                        "install",
+                        "--shell",
+                        "bash",
+                        "--no-add-to-startup",
+                    ],
+                    exit_on_error=False,
+                )
+
+        base_dir = isolated_home / "config" / _CLI_NAME / "completions" / "bash"
+        static_a = list(base_dir.glob("static-*.bash"))
+        assert len(static_a) == 1
+
+        with patch("siesta.completions.shutil.which", return_value=exec_b):
+            with pytest.raises(SystemExit):
+                app(
+                    ["self", "tab-completions", "uninstall", "--shell", "bash"],
+                    exit_on_error=False,
+                )
+
+        # exec_a's static file must still be there
+        assert static_a[0].exists()
+
+    def test_uninstall_zsh(self, isolated_home, mock_which, mock_generate_completion):
+        self._do_install("zsh", isolated_home, mock_which, mock_generate_completion)
+        base_dir = isolated_home / "config" / _CLI_NAME / "completions" / "zsh"
+        assert (base_dir / "hook.zsh").exists()
+
+        with pytest.raises(SystemExit):
+            app(
+                ["self", "tab-completions", "uninstall", "--shell", "zsh"],
+                exit_on_error=False,
+            )
+
+        assert not (base_dir / "hook.zsh").exists()
+        assert list(base_dir.glob("static-*.zsh")) == []
+
+
+# ---------------------------------------------------------------------------
+# TestShow — `self tab-completions show`
+# ---------------------------------------------------------------------------
+
+
+class TestShow:
+    def test_show_bash(self, capsys, monkeypatch):
+        monkeypatch.setenv("SHELL", "/bin/bash")
+        with patch.object(
+            cyclopts.App,
+            "generate_completion",
+            return_value="# Bash completion for siesta\n",
+        ) as mock_gen:
+            with pytest.raises(SystemExit):
+                app(
+                    ["self", "tab-completions", "show", "--shell", "bash"],
+                    exit_on_error=False,
+                )
+
+        mock_gen.assert_called_once()
+        assert mock_gen.call_args.kwargs["shell"] == "bash"
+        assert "Bash completion for siesta" in capsys.readouterr().out
+
+    def test_show_zsh(self, capsys):
+        with patch.object(
+            cyclopts.App,
+            "generate_completion",
+            return_value="# Zsh completion\n",
+        ) as mock_gen:
+            with pytest.raises(SystemExit):
+                app(
+                    ["self", "tab-completions", "show", "--shell", "zsh"],
+                    exit_on_error=False,
+                )
+
+        mock_gen.assert_called_once()
+        assert mock_gen.call_args.kwargs["shell"] == "zsh"
+        assert "Zsh completion" in capsys.readouterr().out
+
+    def test_show_bash_real_script(self, capsys):
+        """Integration: real bash completion script contains top-level commands."""
+        with pytest.raises(SystemExit):
+            app(
+                ["self", "tab-completions", "show", "--shell", "bash"],
+                exit_on_error=False,
+            )
+        out = capsys.readouterr().out
+        assert "# Bash completion" in out
+        # Top-level siesta commands must appear in the completion script.
+        assert "tab-completions" in out
+
+    def test_show_defaults_to_detected_shell(self, monkeypatch, capsys):
+        monkeypatch.setenv("SHELL", "/bin/zsh")
+        with patch.object(
+            cyclopts.App,
+            "generate_completion",
+            return_value="# Zsh completion\n",
+        ) as mock_gen:
+            with pytest.raises(SystemExit):
+                app(["self", "tab-completions", "show"], exit_on_error=False)
+        mock_gen.assert_called_once()
+        assert mock_gen.call_args.kwargs["shell"] == "zsh"
+
+
+# ---------------------------------------------------------------------------
+# TestWhere — `self tab-completions where`
+# ---------------------------------------------------------------------------
+
+
+class TestWhere:
+    def test_where_shows_paths(self, isolated_home, mock_which, capsys, monkeypatch):
+        monkeypatch.setenv("SHELL", "/bin/bash")
+        with pytest.raises(SystemExit):
+            app(
+                ["self", "tab-completions", "where", "--shell", "bash"],
+                exit_on_error=False,
+            )
+        out = capsys.readouterr().out
+        assert "hook_file" in out or "Hook file" in out
+        assert "bash" in out
+
+    def test_where_shows_missing_when_not_installed(
+        self, isolated_home, mock_which, capsys
+    ):
+        with pytest.raises(SystemExit):
+            app(
+                ["self", "tab-completions", "where", "--shell", "bash", "--simple"],
+                exit_on_error=False,
+            )
+        out = capsys.readouterr().out
+        assert "missing" in out
+
+    def test_where_shows_exists_after_install(
+        self, isolated_home, mock_which, mock_generate_completion, capsys
+    ):
+        with pytest.raises(SystemExit):
+            app(
+                ["self", "tab-completions", "install", "--shell", "bash"],
+                exit_on_error=False,
+            )
+        capsys.readouterr()  # discard install output
+
+        with pytest.raises(SystemExit):
+            app(
+                ["self", "tab-completions", "where", "--shell", "bash", "--simple"],
+                exit_on_error=False,
+            )
+        out = capsys.readouterr().out
+        assert "exists" in out
+
+    def test_where_defaults_to_detected_shell(
+        self, isolated_home, mock_which, capsys, monkeypatch
+    ):
+        monkeypatch.setenv("SHELL", "/bin/zsh")
+        with pytest.raises(SystemExit):
+            app(["self", "tab-completions", "where"], exit_on_error=False)
+        out = capsys.readouterr().out
+        assert "zsh" in out
+
+    def test_where_simple_no_table(self, isolated_home, mock_which, capsys):
+        with pytest.raises(SystemExit):
+            app(
+                ["self", "tab-completions", "where", "--shell", "bash", "--simple"],
+                exit_on_error=False,
+            )
+        out = capsys.readouterr().out
+        assert "Base directory:" in out
+        assert "Hook file:" in out
+        # Rich table border characters should not be present
+        assert "─" not in out
+        assert "│" not in out
+
+    def test_where_simple_shows_status(self, isolated_home, mock_which, capsys):
+        with pytest.raises(SystemExit):
+            app(
+                ["self", "tab-completions", "where", "--shell", "bash", "--simple"],
+                exit_on_error=False,
+            )
+        out = capsys.readouterr().out
+        assert "missing" in out
+
+
+# ---------------------------------------------------------------------------
+# TestDetectCurrentShell
+# ---------------------------------------------------------------------------
+
+
+class TestDetectCurrentShell:
+    def test_zsh_path_returns_zsh(self, monkeypatch):
+        monkeypatch.setenv("SHELL", "/bin/zsh")
+        assert detect_current_shell() == "zsh"
+
+    def test_bash_path_returns_bash(self, monkeypatch):
+        monkeypatch.setenv("SHELL", "/bin/bash")
+        assert detect_current_shell() == "bash"
+
+    def test_homebrew_zsh_path_returns_zsh(self, monkeypatch):
+        monkeypatch.setenv("SHELL", "/opt/homebrew/bin/zsh")
+        assert detect_current_shell() == "zsh"
+
+    def test_unsupported_shell_returns_none(self, monkeypatch):
+        monkeypatch.setenv("SHELL", "/usr/bin/fish")
+        assert detect_current_shell() is None
+
+    def test_empty_shell_returns_none(self, monkeypatch):
+        monkeypatch.setenv("SHELL", "")
+        assert detect_current_shell() is None
+
+    def test_missing_shell_env_returns_none(self, monkeypatch):
+        monkeypatch.delenv("SHELL", raising=False)
+        assert detect_current_shell() is None
+
+
+# ---------------------------------------------------------------------------
+# TestIsCompletionInstalled
+# ---------------------------------------------------------------------------
+
+
+class TestIsCompletionInstalled:
+    def test_returns_true_when_hook_file_exists(self, isolated_home, mock_which):
+        exec_id = stable_exec_id(str(Path(FAKE_EXEC).resolve()))
+        paths = managed_completion_paths("zsh", exec_id)
+        paths["base_dir"].mkdir(parents=True, exist_ok=True)
+        paths["hook_file"].touch()
+
+        assert is_completion_installed("zsh") is True
+
+    def test_returns_false_when_hook_file_absent(self, isolated_home, mock_which):
+        assert is_completion_installed("bash") is False
+
+    def test_checks_correct_shell(self, isolated_home, mock_which):
+        exec_id = stable_exec_id(str(Path(FAKE_EXEC).resolve()))
+        bash_paths = managed_completion_paths("bash", exec_id)
+        bash_paths["base_dir"].mkdir(parents=True, exist_ok=True)
+        bash_paths["hook_file"].touch()
+
+        assert is_completion_installed("bash") is True
+        assert is_completion_installed("zsh") is False
+
+
+# ---------------------------------------------------------------------------
+# TestShellDefaulting — auto-detect and error behavior
+# ---------------------------------------------------------------------------
+
+
+class TestShellDefaulting:
+    def test_install_uses_detected_shell(
+        self, isolated_home, mock_which, mock_generate_completion, monkeypatch
+    ):
+        """Omitting ``--shell`` falls back to ``$SHELL``."""
+        monkeypatch.setenv("SHELL", "/bin/bash")
+        with pytest.raises(SystemExit):
+            app(["self", "tab-completions", "install"], exit_on_error=False)
+
+        base_dir = isolated_home / "config" / _CLI_NAME / "completions" / "bash"
+        assert (base_dir / "hook.bash").exists()
+
+    def test_uninstall_uses_detected_shell(
+        self, isolated_home, mock_which, mock_generate_completion, monkeypatch
+    ):
+        """Omitting ``--shell`` from uninstall falls back to ``$SHELL``."""
+        monkeypatch.setenv("SHELL", "/bin/zsh")
+        # install first
+        with pytest.raises(SystemExit):
+            app(
+                ["self", "tab-completions", "install", "--shell", "zsh"],
+                exit_on_error=False,
+            )
+        base_dir = isolated_home / "config" / _CLI_NAME / "completions" / "zsh"
+        assert (base_dir / "hook.zsh").exists()
+
+        # uninstall without --shell
+        with pytest.raises(SystemExit):
+            app(["self", "tab-completions", "uninstall"], exit_on_error=False)
+        assert not (base_dir / "hook.zsh").exists()
+
+    def test_install_errors_when_shell_undetectable(
+        self, isolated_home, mock_which, mock_generate_completion, monkeypatch, capsys
+    ):
+        """When ``$SHELL`` is not bash/zsh and ``--shell`` is absent, exit 1."""
+        monkeypatch.setenv("SHELL", "/usr/bin/fish")
+        with pytest.raises(SystemExit) as exc_info:
+            app(["self", "tab-completions", "install"], exit_on_error=False)
+        assert exc_info.value.code != 0
+        out = capsys.readouterr().out
+        assert "--shell" in out
+
+    def test_show_errors_when_shell_undetectable(self, monkeypatch, capsys):
+        """When ``$SHELL`` is unrecognised and ``--shell`` is absent, exit 1."""
+        monkeypatch.setenv("SHELL", "/usr/bin/fish")
+        with pytest.raises(SystemExit) as exc_info:
+            app(["self", "tab-completions", "show"], exit_on_error=False)
+        assert exc_info.value.code != 0
+        out = capsys.readouterr().out
+        assert "--shell" in out
+
+    def test_where_errors_when_shell_undetectable(
+        self, isolated_home, mock_which, monkeypatch, capsys
+    ):
+        """When ``$SHELL`` is unrecognised and ``--shell`` is absent, exit 1."""
+        monkeypatch.setenv("SHELL", "/usr/bin/fish")
+        with pytest.raises(SystemExit) as exc_info:
+            app(["self", "tab-completions", "where"], exit_on_error=False)
+        assert exc_info.value.code != 0
+        out = capsys.readouterr().out
+        assert "--shell" in out
+
+    def test_uninstall_errors_when_shell_undetectable(
+        self, isolated_home, mock_which, monkeypatch, capsys
+    ):
+        """When ``$SHELL`` is unrecognised and ``--shell`` is absent, exit 1."""
+        monkeypatch.setenv("SHELL", "/usr/bin/fish")
+        with pytest.raises(SystemExit) as exc_info:
+            app(["self", "tab-completions", "uninstall"], exit_on_error=False)
+        assert exc_info.value.code != 0
+        out = capsys.readouterr().out
+        assert "--shell" in out
+
+
+# ---------------------------------------------------------------------------
+# TestHelpEpilogue — completion hint in help output
+# ---------------------------------------------------------------------------
+
+
+class TestHelpEpilogue:
+    def test_tip_appears_in_help_when_epilogue_set(self, capsys):
+        """When help_epilogue is set, it appears in --help output."""
+        original = app.help_epilogue
+        try:
+            app.help_epilogue = (
+                "Tip: enable tab completions with "
+                "`siesta self tab-completions install`"
+            )
+            with pytest.raises(SystemExit):
+                app(["--help"], exit_on_error=False)
+            out = capsys.readouterr().out
+            assert "enable tab completions" in out
+            assert "siesta self tab-completions install" in out
+        finally:
+            app.help_epilogue = original
+
+    def test_tip_absent_when_epilogue_not_set(self, capsys):
+        """When help_epilogue is None, no tip appears in --help output."""
+        original = app.help_epilogue
+        try:
+            app.help_epilogue = None
+            with pytest.raises(SystemExit):
+                app(["--help"], exit_on_error=False)
+            out = capsys.readouterr().out
+            assert "enable tab completions" not in out
+        finally:
+            app.help_epilogue = original
+
+    def test_tip_propagates_to_subcommand_help(self, capsys):
+        """Epilogue set on root app propagates to sub-command help."""
+        original = app.help_epilogue
+        try:
+            app.help_epilogue = (
+                "Tip: enable tab completions with "
+                "`siesta self tab-completions install`"
+            )
+            with pytest.raises(SystemExit):
+                app(["self", "--help"], exit_on_error=False)
+            out = capsys.readouterr().out
+            assert "enable tab completions" in out
+        finally:
+            app.help_epilogue = original

--- a/tests/test_cli/test_watch_docs.py
+++ b/tests/test_cli/test_watch_docs.py
@@ -30,7 +30,10 @@ def test_watch_docs_observer_setup(module_test_path, monkeypatch, capture_output
         patch("time.sleep", side_effect=KeyboardInterrupt),
     ):
         with capture_output() as output:
-            app(["docs", "watch"])
+            try:
+                app(["docs", "watch"])
+            except SystemExit as e:
+                assert e.code == 0
 
     # Verify observer was started
     assert mock_observer_instance.start.called
@@ -79,7 +82,10 @@ def test_watch_docs_custom_patterns(module_test_path, monkeypatch, capture_outpu
         patch("time.sleep", side_effect=KeyboardInterrupt),
     ):
         with capture_output():
-            app(["docs", "watch", "--patterns", custom_patterns])
+            try:
+                app(["docs", "watch", "--patterns", custom_patterns])
+            except SystemExit as e:
+                assert e.code == 0
 
     # Verify observer was scheduled with handler using custom patterns
     schedule_call = mock_observer.return_value.schedule.call_args[0]

--- a/uv.lock
+++ b/uv.lock
@@ -376,17 +376,17 @@ wheels = [
 
 [[package]]
 name = "cyclopts"
-version = "3.0.0"
+version = "4.10.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
-    { name = "docstring-parser", marker = "python_full_version < '4'" },
+    { name = "docstring-parser" },
     { name = "rich" },
     { name = "rich-rst" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/da/c9/7af788b46a902c60098515c80fb159cbb2e7d6aaed21190dbea12ca446f7/cyclopts-3.0.0.tar.gz", hash = "sha256:603389e7bb28e54828e2a30c300158db3e1bf0666065d0ba5f1c0dfa7d1eb5f8", size = 59872, upload-time = "2024-11-09T01:55:48.748Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/c4/2ce2ca1451487dc7d59f09334c3fa1182c46cfcf0a2d5f19f9b26d53ac74/cyclopts-4.10.1.tar.gz", hash = "sha256:ad4e4bb90576412d32276b14a76f55d43353753d16217f2c3cd5bdceba7f15a0", size = 166623, upload-time = "2026-03-23T14:43:01.098Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/67/d5/482b7a240c6c229704a7e04a4bc9ece1b64414fac9291855cca9138cba0b/cyclopts-3.0.0-py3-none-any.whl", hash = "sha256:d780f08218c7e51ee897ae3adfaf7664508c471f444ec664090df77aad4218f1", size = 67841, upload-time = "2024-11-09T01:55:47.731Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/0b/2261922126b2e50c601fe22d7ff5194e0a4d50e654836260c0665e24d862/cyclopts-4.10.1-py3-none-any.whl", hash = "sha256:35f37257139380a386d9fe4475e1e7c87ca7795765ef4f31abba579fcfcb6ecd", size = 204331, upload-time = "2026-03-23T14:43:02.625Z" },
 ]
 
 [[package]]
@@ -1559,7 +1559,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cyclopts", specifier = ">=2.9.9" },
+    { name = "cyclopts", specifier = ">=4.4.5" },
     { name = "gitignore-parser", specifier = ">=0.1.13" },
     { name = "keyring", specifier = ">=25.5.0" },
     { name = "packaging", specifier = ">=24.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -1522,7 +1522,7 @@ wheels = [
 
 [[package]]
 name = "siesta"
-version = "1.1.1"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "cyclopts" },


### PR DESCRIPTION
## TL;DR

Add managed shell tab-completion support (`siesta self tab-completions install/uninstall/show/where`) for bash and zsh, with zero-startup-cost hooks that auto-refresh when the CLI is upgraded. Bump cyclopts to 4.x and siesta to 1.2.0.

## Breaking changes 🔥

- 🟡 **cyclopts major version bump (2.x → 4.x)**: cyclopts 4.x calls `sys.exit(0)` on successful command completion. All existing tests have been updated to handle this. Users invoking `app()` programmatically must now catch `SystemExit`.

## Changes

- **Completions module** (`src/siesta/completions.py`): New standalone module for generating, installing, and uninstalling managed bash/zsh completion hooks. Uses XDG-compliant config paths, SHA-256-based exec IDs for multi-install isolation, and a lazy refresh mechanism that only spawns Python on first CLI use after an upgrade.
- **CLI subcommands**: Add `siesta self tab-completions {install,uninstall,show,where}` with auto-detected shell defaulting, `--shell` override, and `--no-add-to-startup` option.
- **Help epilogue hint**: Show a "Tip: enable tab completions" message in `--help` output when completions are not installed. Evaluation is deferred to `main()` to avoid import-time side effects.
- **Security hardening**: Use single-quoted paths in generated shell hooks and RC source lines to prevent shell injection via `$XDG_CONFIG_HOME` or paths with metacharacters. Add portable SHA-256 helper (`sha256sum || shasum`) for Linux compatibility. Treat empty `$XDG_CONFIG_HOME` as unset per XDG spec.
- **cyclopts upgrade**: Bump from `>=2.9.9` to `>=4.4.5` for `help_epilogue` support. Adapt all existing tests to handle the new `sys.exit(0)` behavior.
- **Version bump**: siesta 1.1.1 → 1.2.0.

## Review hints

- The shell hook templates in `completions.py:render_shell_hook()` are the most complex part — they generate bash/zsh scripts with f-string interpolation. The single-quoting fix prevents injection but the templates are inherently dense.
- The refresh integration tests (`TestRefreshBehavior`) spawn real bash/zsh subprocesses with a fake siesta stub — they're the most CI-sensitive tests.
- No database or API changes. No changes to existing CLI command signatures.
