### PR TITLE
Refactor: Prompt first in cli.py before any mutation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ Every work item follows the same cycle:
 8. **Adversarial review** - Spawn a sub-agent whose explicit task is to adversarially review the implementation and assess security risks
 9. **Commit** — one issue = one commit, conventional message, `Refs #<num>` in the footer.
 10. **Close** — update the issue with the commit hash, switch label to `agent:done`, close the issue.
+11. **Wrap-up** — when implementation is done, run the `/wrap-up-branch` skill to finalize branch readiness.
 
 ## Always-on rules
 
@@ -30,6 +31,7 @@ Every work item follows the same cycle:
 5. **Plans live in the issue's managed comment.** Local drafts in `plans/` are allowed for noisy iteration but must be published to the comment at four checkpoints: end of scouting, start of build, before commit, after commit.
 6. **GitHub state wins.** When the issue and any local artifact (e.g. `plans/`) disagree, the issue is correct.
 7. **Never publish secrets** into issue bodies or comments — tokens, `.env` contents, `gh auth token` output, credentials, PII, customer data. Treat issues as world-readable until proven otherwise.
+8. **Use wrap-up skill at the end.** After implementation and critique are complete, use `/wrap-up-branch` before considering the work finished.
 
 ## Worktrees
 
@@ -57,6 +59,7 @@ If the next pickup is a scouted issue:
 ## Skills index
 
 - [`.skills/github-issue-workflow/SKILL.md`](.skills/github-issue-workflow/SKILL.md) — `gh` mechanics for the `agent:todo` issue lifecycle: claiming, managed plan comments, label transitions.
+- `/wrap-up-branch` — required end-of-task branch finalization workflow once implementation is complete.
 
 ## Local artifacts
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,17 @@ A scout prepares the ground for a builder. This is how we have partial parallel 
 - Scouts **do not commit**.
 - Multiple scouts may run in parallel; each writes a distinct local draft and updates its own issue's managed comment.
 
+### Parallel scouting interview workflow
+
+When multiple scout sub-agents run in parallel, each scout must follow this interaction contract:
+
+- **Branch baseline first.** Scout from the branch declared in the issue body. If no valid branch is declared, default to `main` and explicitly note that fallback in the managed comment.
+- **Worktree when not on main.** If the effective scouting branch is not `main`, use a dedicated worktree for that scout.
+- **Mandatory grilling.** Use the `/grill-with-docs` skill during scouting.
+- **One question at a time.** Ask exactly one clarifying question, include a recommended answer, then stop and wait for the user before continuing.
+- **Track Q&A in GitHub.** Every question/answer turn must be appended to the issue's managed comment so the issue remains the source of truth.
+- **Stay read-only.** Question loops are scouting only: no implementation, docs, or test edits.
+
 ## Post-scouting
 
 If the next pickup is a scouted issue:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,8 +19,8 @@ Every work item follows the same cycle:
 7. **Critique & feedback** — summarize what changed, what was verified, residual risks.
 8. **Adversarial review** - Spawn a sub-agent whose explicit task is to adversarially review the implementation and assess security risks
 9. **Commit** — one issue = one commit, conventional message, `Refs #<num>` in the footer.
-10. **Close** — update the issue with the commit hash, switch label to `agent:done`, close the issue.
-11. **Wrap-up** — when implementation is done, run the `/wrap-up-branch` skill to finalize branch readiness.
+10. **Wrap-up** — when implementation is done, run the `/wrap-up-branch` skill to finalize branch readiness.
+11. **Close** — update the issue with the commit hash, switch label to `agent:done`, close the issue.
 
 ## Always-on rules
 
@@ -31,7 +31,7 @@ Every work item follows the same cycle:
 5. **Plans live in the issue's managed comment.** Local drafts in `plans/` are allowed for noisy iteration but must be published to the comment at four checkpoints: end of scouting, start of build, before commit, after commit.
 6. **GitHub state wins.** When the issue and any local artifact (e.g. `plans/`) disagree, the issue is correct.
 7. **Never publish secrets** into issue bodies or comments — tokens, `.env` contents, `gh auth token` output, credentials, PII, customer data. Treat issues as world-readable until proven otherwise.
-8. **Use wrap-up skill at the end.** After implementation and critique are complete, use `/wrap-up-branch` before considering the work finished.
+8. **Use wrap-up skill before close.** Follow lifecycle order: run `/wrap-up-branch` after commit/critique and before closing the issue.
 
 ## Worktrees
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,34 @@
+# Context
+
+## Glossary
+
+### Mutation
+An operation that changes project state, including filesystem writes and external side effects.
+
+### Prompt Collection Phase
+The initial command phase where all user decisions are gathered before any mutation is allowed.
+
+### Execution Phase
+The phase that starts after prompt collection and performs only the mutations selected by the user.
+
+### Non-Interactive Resolution
+Mode where no prompts are shown; command decisions are resolved from explicit flags first, then CLI defaults.
+
+### Cancellation
+User interruption during prompt collection that exits with code 130 at the CLI
+entrypoint and must occur before any mutation.
+
+### Validation Phase
+Fail-fast, non-mutating checks that run before prompt collection to reject invalid command contexts.
+
+### No-Op Selection
+A valid outcome where the user selects no actions; command exits successfully without mutation.
+
+### Decision Ownership
+The top-level invoked command owns prompt collection for all downstream actions and passes explicit decisions to helper or nested command calls.
+
+### Ordering Contract
+Behavioral guarantee that decision collection completes before the first mutating operation starts.
+
+### Input Precedence
+Explicit CLI flags are authoritative; prompts are used only to resolve unspecified decisions.

--- a/docs/adr/0001-prompt-first-command-execution.md
+++ b/docs/adr/0001-prompt-first-command-execution.md
@@ -1,0 +1,41 @@
+# ADR 0001: Prompt-First Command Execution
+
+## Status
+Accepted
+
+## Context
+Write-oriented CLI commands currently interleave user prompting and state mutations.
+If the user interrupts during a late prompt, the repository may be left in a
+partially modified state.
+
+The same risk appears across multiple commands, not just one entrypoint.
+
+## Decision
+Adopt a two-phase command model for write-oriented commands:
+
+1. Run non-mutating validation checks.
+2. Collect all user decisions (prompt collection phase).
+3. Execute mutations only after decision collection is complete.
+
+Mutation includes both filesystem writes and external side effects.
+
+For commands that support non-interactive defaults, no prompts are shown in
+non-interactive mode. Decisions are resolved from explicit flags first, then
+CLI defaults.
+
+## Consequences
+Positive:
+- Interruptions during decision collection cannot leave partially applied changes.
+- Command behavior becomes more predictable and testable via an ordering contract.
+- Top-level commands can own decision collection and pass explicit choices to
+  nested command calls.
+
+Trade-offs:
+- Commands need explicit separation between decision logic and mutation logic.
+- Some prompt flows become less conversational and more up-front.
+
+## Alternatives Considered
+- Keep current interleaved prompt/write flow and rely on best effort cleanup.
+  Rejected because it cannot guarantee zero mutation on cancellation.
+- Implement rollback after each mutation.
+  Rejected for complexity and incomplete rollback guarantees across side effects.

--- a/src/siesta/cli.py
+++ b/src/siesta/cli.py
@@ -599,15 +599,8 @@ def init_docs(
             logger.warning(f"Path already exists: {path}")
             logger.warning("Use --overwrite to overwrite.")
             logger.abort("Aborting.", exit=1)
-        # user wants to overwrite -> remove the folder and warn
-        logger.warning("🚧 Overwriting path.")
-        rmtree(path)
 
-    # Create the docs folder
-    path.mkdir(parents=True)
-    logger.success("Docs initialized 📄")
-
-    # Whether to install dependencies
+    # Prompt collection phase: gather decisions before any mutation.
     if deps is None:
         deps = logger.confirm("Would you like to install recommended dependencies?")
 
@@ -615,18 +608,30 @@ def init_docs(
     if deps:
         # Check if uv.lock exists in order to decide whether to use uv or not
         if resolve_path("./uv.lock").exists():
-            with_uv = (
-                uv
-                or not interactive  # if not interactive, assume uv since uv.lock exists
-                or logger.confirm(
+            if uv is not None:
+                with_uv = uv
+            elif not interactive:  # if not interactive, assume uv since uv.lock exists
+                with_uv = True
+            else:
+                with_uv = logger.confirm(
                     "It looks like you are using uv. Use `uv add` to add dependencies?"
                 )
-            )
         else:
             if uv:
                 logger.warning(
                     "uv.lock not found. Skipping uv dependencies, installing with pip."
                 )
+
+    # Execution phase: perform mutations only after all decisions are collected.
+    if path.exists():
+        logger.warning("🚧 Overwriting path.")
+        rmtree(path)
+
+    path.mkdir(parents=True)
+    logger.success("Docs initialized 📄")
+
+    # Install dependencies if requested.
+    if deps:
         logger.info(f"Installing docs dependencies{' with uv.' if with_uv else '.'}..")
         # Execute the command to install dependencies
         install_dependencies(with_uv, with_uv and not as_main_deps)
@@ -700,8 +705,20 @@ def update(
     if not path.exists():
         logger.abort(f"Path not found: {path}", exit=1)
 
-    # Confirm to overwrite the documentation's HTML static files
-    if logger.confirm("Overwrite the documentation's HTML static files. Continue?"):
+    # Prompt collection phase: gather all confirmations up front.
+    update_static = logger.confirm(
+        "Overwrite the documentation's HTML static files. Continue?"
+    )
+    update_conf = logger.confirm("Would you like to update the conf.py file?")
+    update_precommit = logger.confirm("Would you like to update the pre-commit hooks?")
+
+    if not any([update_static, update_conf, update_precommit]):
+        logger.info("No updates selected. Nothing to do.")
+        logger.success("Done.")
+        return
+
+    # Execution phase: run only the selected mutating actions.
+    if update_static:
         static = path / "source" / "_static"
         if not static.exists():
             logger.abort(f"Static folder not found: {static}", exit=1)
@@ -715,13 +732,11 @@ def update(
         )
         logger.success("Static files updated.")
 
-    # Update the conf.py file
-    if logger.confirm("Would you like to update the conf.py file?"):
+    if update_conf:
         update_conf_py(path, branch=branch, local=not remote_assets)
         logger.success("[r]conf.py[/r] updated.")
 
-    # Update the pre-commit hooks
-    if logger.confirm("Would you like to update the pre-commit hooks?"):
+    if update_precommit:
         write_or_update_pre_commit_file()
         has_uv = Path("uv.lock").exists()
         if has_uv:
@@ -981,7 +996,43 @@ def quickstart_project(
         if gitignore is None:
             gitignore = CLI_DEFAULTS["gitignore"]
 
-    # Check if the project is already initialized
+    # Prompt collection phase: gather all unresolved decisions before mutations.
+    if deps is None:
+        deps = logger.confirm("Would you like to install recommended dependencies?")
+
+    if precommit is None:
+        precommit = logger.confirm(
+            "Would you like to update & install pre-commit hooks?"
+        )
+
+    if ipdb is None:
+        ipdb = logger.confirm("Would you like to add ipdb as debugger?")
+
+    if tests is None:
+        tests = logger.confirm("Would you like to initialize (pytest) tests infra?")
+
+    if actions is None:
+        actions = logger.confirm("Would you like to initialize GitHub Actions?")
+
+    if gitignore is None:
+        gitignore = logger.confirm(
+            "Would you like to initialize the ``.gitignore`` file?"
+        )
+
+    if docs is None:
+        docs = logger.confirm("Would you like to initialize the docs?")
+
+    docs_with_uv: bool | None = None
+    if docs and deps:
+        if Path("uv.lock").exists():
+            if interactive:
+                docs_with_uv = logger.confirm(
+                    "It looks like you are using uv. Use `uv add` to add dependencies?"
+                )
+            else:
+                docs_with_uv = True
+
+    # Execution phase: perform mutations after all decisions are collected.
     has_uv_lock = Path("uv.lock").exists()
     if not has_uv_lock:
         cmd = ["uv", "init"]
@@ -1003,9 +1054,6 @@ def quickstart_project(
     else:
         logger.info("Project already initialized with uv.")
 
-    # Install dependencies
-    if deps is None:
-        deps = logger.confirm("Would you like to install recommended dependencies?")
     if deps:
         dev_deps = load_deps()["dev"]
         installed = run_command(["uv", "add", "--dev"] + dev_deps)
@@ -1013,11 +1061,6 @@ def quickstart_project(
             logger.abort("Failed to install the dev dependencies.")
         logger.info("Dev dependencies installed.")
 
-    # Install pre-commit hooks
-    if precommit is None:
-        precommit = logger.confirm(
-            "Would you like to update & install pre-commit hooks?"
-        )
     if precommit:
         write_or_update_pre_commit_file()
         pre_commit_installed = run_command(["uv", "run", "pre-commit", "install"])
@@ -1025,57 +1068,45 @@ def quickstart_project(
             logger.abort("Failed to install pre-commit hooks.")
         logger.info("Pre-commit hooks installed.")
 
-    if ipdb is None:
-        ipdb = logger.confirm("Would you like to add ipdb as debugger?")
     if ipdb:
         add_ipdb_as_debugger()
         logger.info("[r]ipdb[/r] added as debugger.")
-    if tests is None:
-        tests = logger.confirm("Would you like to initialize (pytest) tests infra?")
+
     if tests:
-        # Use setup_tests but skip deps (already installed above) and set interactive=True
-        # since we already processed defaults above
+        # Decision ownership stays in quickstart; setup-tests receives explicit values.
         setup_tests(
             project_name=project_name,
             actions=actions,
             deps=False,  # deps already handled by quickstart
-            interactive=True,  # we already processed defaults above
+            interactive=False,
         )
-    else:
-        # Handle GitHub Actions independently when tests are skipped
-        # (setup_tests normally handles this, but we're not calling it)
-        if actions is None:
-            actions = logger.confirm("Would you like to initialize GitHub Actions?")
-        if actions:
-            # Warn if user wants CI but has no tests
-            if not Path("tests").exists():
-                logger.warning(
-                    "You're setting up GitHub Actions CI without tests. "
-                    "Either add tests later or update [r].github/workflows/test.yml[/r] "
-                    "to match your project's needs."
-                )
-            write_test_actions_config()
-            logger.info("Test actions config written.")
-    if gitignore is None:
-        gitignore = logger.confirm(
-            "Would you like to initialize the ``.gitignore`` file?"
-        )
+    elif actions:
+        # Warn if user wants CI but has no tests
+        if not Path("tests").exists():
+            logger.warning(
+                "You're setting up GitHub Actions CI without tests. "
+                "Either add tests later or update [r].github/workflows/test.yml[/r] "
+                "to match your project's needs."
+            )
+        write_test_actions_config()
+        logger.info("Test actions config written.")
+
     if gitignore:
         write_gitignore()
         logger.info("Gitignore written.")
 
-    if docs is None:
-        docs = logger.confirm("Would you like to initialize the docs?")
     if docs:
         init_docs(
             path=docs_path,
             as_main_deps=as_main_deps,
             overwrite=overwrite,
             deps=deps,
-            interactive=interactive,
+            uv=docs_with_uv,
+            interactive=False,
             branch=branch,
             contents=contents,
             remote_assets=remote_assets,
+            project_name=project_name,
         )
 
     tree_project(".")
@@ -1153,9 +1184,14 @@ def setup_tests(
     # Check if uv is available and uv.lock exists
     has_uv = Path("uv.lock").exists()
 
-    # Install test dependencies
+    # Prompt collection phase: gather decisions before mutations.
     if deps is None:
         deps = logger.confirm("Would you like to install test dependencies?")
+
+    if actions is None:
+        actions = logger.confirm("Would you like to initialize GitHub Actions?")
+
+    # Execution phase: apply selected mutations.
     if deps:
         test_deps = ["pytest", "pytest-cov"]
         if has_uv:
@@ -1173,9 +1209,6 @@ def setup_tests(
     write_tests_infra(project_name)
     logger.info("Tests infra written.")
 
-    # Optionally set up GitHub Actions
-    if actions is None:
-        actions = logger.confirm("Would you like to initialize GitHub Actions?")
     if actions:
         write_test_actions_config()
         logger.info("Test actions config written.")

--- a/tests/test_cli/test_init_docs.py
+++ b/tests/test_cli/test_init_docs.py
@@ -1,6 +1,7 @@
 # Copyright 2025 Entalpic
 import pytest
 
+import siesta.cli as cli
 from siesta.cli import app
 
 
@@ -151,3 +152,82 @@ def test_init_docs_respects_no_deps(
     docs_dir = temp_project_with_git_and_remote / "docs"
     assert docs_dir.exists()
     assert (docs_dir / "source" / "conf.py").exists()
+
+
+def test_init_docs_collects_prompts_before_mutation(
+    temp_project_with_git_and_remote, monkeypatch
+):
+    """Test that docs init collects interactive decisions before mutating state."""
+    monkeypatch.chdir(temp_project_with_git_and_remote)
+    (temp_project_with_git_and_remote / "uv.lock").write_text("")
+    events: list[str] = []
+
+    def fake_confirm(message: str) -> bool:
+        events.append(f"confirm:{message}")
+        return True
+
+    monkeypatch.setattr(cli.logger, "confirm", fake_confirm)
+    monkeypatch.setattr(
+        cli, "install_dependencies", lambda *_args, **_kwargs: events.append("install")
+    )
+    monkeypatch.setattr(
+        cli, "copy_boilerplate", lambda *_args, **_kwargs: events.append("copy")
+    )
+    monkeypatch.setattr(
+        cli, "make_empty_folders", lambda *_args, **_kwargs: events.append("empty")
+    )
+    monkeypatch.setattr(
+        cli, "overwrite_docs_files", lambda *_args, **_kwargs: events.append("overwrite")
+    )
+    monkeypatch.setattr(
+        cli, "write_rtd_config", lambda *_args, **_kwargs: events.append("rtd")
+    )
+    monkeypatch.setattr(cli, "build_docs", lambda *_args, **_kwargs: events.append("build"))
+
+    orig_mkdir = cli.Path.mkdir
+
+    def tracked_mkdir(path_obj, *args, **kwargs):
+        events.append("mkdir")
+        return orig_mkdir(path_obj, *args, **kwargs)
+
+    monkeypatch.setattr(cli.Path, "mkdir", tracked_mkdir)
+
+    with pytest.raises(SystemExit) as exc_info:
+        app(["docs", "init", "-i"])
+    assert exc_info.value.code == 0
+
+    prompt_indices = [i for i, event in enumerate(events) if event.startswith("confirm:")]
+    first_mutation_idx = next(i for i, event in enumerate(events) if not event.startswith("confirm:"))
+    assert prompt_indices
+    assert max(prompt_indices) < first_mutation_idx
+
+
+def test_init_docs_cancel_during_prompt_has_no_mutation(
+    temp_project_with_git_and_remote, monkeypatch
+):
+    """Test cancellation during prompt collection leaves project untouched."""
+    monkeypatch.chdir(temp_project_with_git_and_remote)
+
+    monkeypatch.setattr(
+        cli.logger,
+        "confirm",
+        lambda _message: (_ for _ in ()).throw(KeyboardInterrupt()),
+    )
+    monkeypatch.setattr(
+        cli.Path,
+        "mkdir",
+        lambda *_args, **_kwargs: pytest.fail("mkdir should not be called on cancellation"),
+    )
+    monkeypatch.setattr(
+        cli,
+        "install_dependencies",
+        lambda *_args, **_kwargs: pytest.fail(
+            "install_dependencies should not be called on cancellation"
+        ),
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        app(["docs", "init", "-i"])
+    assert exc_info.value.code == 130
+
+    assert not (temp_project_with_git_and_remote / "docs").exists()

--- a/tests/test_cli/test_quickstart_project.py
+++ b/tests/test_cli/test_quickstart_project.py
@@ -1,6 +1,7 @@
 # Copyright 2025 Entalpic
 from pathlib import Path
 
+import siesta.cli as cli
 from siesta.cli import app
 
 
@@ -136,3 +137,51 @@ def test_quickstart_respects_no_tests_and_no_actions(tmp_path_chdir, capture_out
 
     # Check GitHub Actions does NOT exist (user specified --no-actions)
     assert not Path(tmp_path_chdir, ".github").exists()
+
+
+def test_quickstart_collects_decisions_before_mutations(tmp_path_chdir, monkeypatch):
+    """Test quickstart collects prompts before any mutating command runs."""
+    events: list[str] = []
+    prompts = iter([True, True, True, True, True, True, True])
+
+    def fake_confirm(message: str) -> bool:
+        events.append(f"confirm:{message}")
+        return next(prompts)
+
+    def fake_run_command(cmd, check=True, cwd=None):
+        cmd_str = " ".join(cmd)
+        if cmd == ["uv", "--version"]:
+            events.append("check_uv")
+        else:
+            events.append(f"run:{cmd_str}")
+
+        class Result:
+            stdout = "ok"
+            returncode = 0
+
+        return Result()
+
+    monkeypatch.setattr(cli.logger, "confirm", fake_confirm)
+    monkeypatch.setattr(cli, "get_project_name", lambda _interactive: "test_siesta")
+    monkeypatch.setattr(cli, "run_command", fake_run_command)
+    monkeypatch.setattr(cli, "load_deps", lambda: {"dev": []})
+    monkeypatch.setattr(cli, "write_or_update_pre_commit_file", lambda: events.append("precommit_file"))
+    monkeypatch.setattr(cli, "add_ipdb_as_debugger", lambda: events.append("ipdb"))
+    monkeypatch.setattr(cli, "setup_tests", lambda **_kwargs: events.append("setup_tests"))
+    monkeypatch.setattr(cli, "write_gitignore", lambda: events.append("gitignore"))
+    monkeypatch.setattr(cli, "init_docs", lambda **_kwargs: events.append("init_docs"))
+    monkeypatch.setattr(cli, "tree_project", lambda *_args, **_kwargs: events.append("tree"))
+
+    try:
+        app(["project", "quickstart", "-i"])
+    except SystemExit as e:
+        assert e.code == 0
+
+    first_mutation = next(
+        i
+        for i, event in enumerate(events)
+        if event != "check_uv" and not event.startswith("confirm:")
+    )
+    prompt_indices = [i for i, event in enumerate(events) if event.startswith("confirm:")]
+    assert prompt_indices
+    assert max(prompt_indices) < first_mutation

--- a/tests/test_cli/test_setup_tests.py
+++ b/tests/test_cli/test_setup_tests.py
@@ -5,6 +5,7 @@ from subprocess import run
 
 import pytest
 
+import siesta.cli as cli
 from siesta.cli import app
 
 
@@ -186,3 +187,42 @@ def test_setup_tests_interactive_flag(existing_uv_project, capture_output):
 
     # Check GitHub Actions was NOT created (we specified --no-actions)
     assert not (existing_uv_project / ".github").exists()
+
+
+def test_setup_tests_collects_decisions_before_mutations(existing_uv_project, monkeypatch):
+    """Test setup-tests collects prompts before mutating project state."""
+    monkeypatch.chdir(existing_uv_project)
+    events: list[str] = []
+    answers = iter([True, True])
+
+    monkeypatch.setattr(
+        cli.logger,
+        "confirm",
+        lambda _msg: events.append("confirm") or next(answers),
+    )
+    monkeypatch.setattr(
+        cli,
+        "run_command",
+        lambda cmd, **_kwargs: events.append(f"run:{' '.join(cmd)}") or True,
+    )
+    monkeypatch.setattr(
+        cli, "write_tests_infra", lambda *_args, **_kwargs: events.append("write_tests_infra")
+    )
+    monkeypatch.setattr(
+        cli,
+        "write_test_actions_config",
+        lambda *_args, **_kwargs: events.append("write_test_actions_config"),
+    )
+
+    try:
+        app(["project", "setup-tests", "-i", "--project-name=existing_project"])
+    except SystemExit as e:
+        assert e.code == 0
+
+    first_mutation = next(i for i, event in enumerate(events) if event != "confirm")
+    confirm_indices = [i for i, event in enumerate(events) if event == "confirm"]
+    assert confirm_indices
+    assert max(confirm_indices) < first_mutation
+    assert events[first_mutation].startswith("run:")
+    assert "write_tests_infra" in events
+    assert "write_test_actions_config" in events

--- a/tests/test_cli/test_update_docs.py
+++ b/tests/test_cli/test_update_docs.py
@@ -1,0 +1,75 @@
+# Copyright 2025 Entalpic
+import siesta.cli as cli
+from siesta.cli import app
+
+
+def test_update_docs_no_selection_is_noop(tmp_path, monkeypatch, capture_output):
+    """Test docs update exits cleanly when user selects no actions."""
+    docs_path = tmp_path / "docs"
+    (docs_path / "source" / "_static").mkdir(parents=True)
+    monkeypatch.chdir(tmp_path)
+
+    monkeypatch.setattr(cli.logger, "confirm", lambda _message: False)
+    monkeypatch.setattr(
+        cli,
+        "copy_boilerplate",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("copy_boilerplate should not run on no-op selection")
+        ),
+    )
+    monkeypatch.setattr(
+        cli,
+        "update_conf_py",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("update_conf_py should not run on no-op selection")
+        ),
+    )
+    monkeypatch.setattr(
+        cli,
+        "write_or_update_pre_commit_file",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("pre-commit update should not run on no-op selection")
+        ),
+    )
+
+    with capture_output() as output:
+        try:
+            app(["docs", "update"])
+        except SystemExit as e:
+            assert e.code == 0
+
+    assert "No updates selected. Nothing to do." in output.getvalue()
+
+
+def test_update_docs_collects_all_decisions_upfront(tmp_path, monkeypatch):
+    """Test docs update asks all prompts before executing selected actions."""
+    docs_path = tmp_path / "docs"
+    (docs_path / "source" / "_static").mkdir(parents=True)
+    monkeypatch.chdir(tmp_path)
+    events: list[str] = []
+    answers = iter([False, True, False])
+
+    def fake_confirm(message: str) -> bool:
+        events.append(f"confirm:{message}")
+        return next(answers)
+
+    monkeypatch.setattr(cli.logger, "confirm", fake_confirm)
+    monkeypatch.setattr(
+        cli, "update_conf_py", lambda *_args, **_kwargs: events.append("update_conf_py")
+    )
+    monkeypatch.setattr(
+        cli, "copy_boilerplate", lambda *_args, **_kwargs: events.append("copy")
+    )
+
+    try:
+        app(["docs", "update"])
+    except SystemExit as e:
+        assert e.code == 0
+
+    assert events[:3] == [
+        "confirm:Overwrite the documentation's HTML static files. Continue?",
+        "confirm:Would you like to update the conf.py file?",
+        "confirm:Would you like to update the pre-commit hooks?",
+    ]
+    assert "update_conf_py" in events
+    assert "copy" not in events


### PR DESCRIPTION
## TL;DR

Split write-oriented CLI command flows into validation, prompt collection, and execution phases so prompts happen before any mutation. Make no-op and cancellation behavior explicit, and document the ordering contract in project docs.

## Breaking changes 🔥

None.

## Changes

- **Prompt-first execution model**: Collect unresolved decisions up front in `docs init`, `docs update`, `project quickstart`, and `project setup-tests`, then execute only selected mutations.
- **Behavioral safety**: Add explicit no-op handling for `docs update` when no action is selected and preserve cancellation semantics so interrupting prompts exits before writes.
- **Tests and docs**: Add ordering and cancellation tests across CLI flows, plus `CONTEXT.md` glossary/contract terms and ADR `0001` to codify the two-phase model.
- **Agent workflow policy**: Require `/wrap-up-branch` before issue close and add parallel scouting interview rules in `AGENTS.md`.

## Review hints

- Inspect prompt-to-mutation ordering in `src/siesta/cli.py` for `init_docs`, `update`, `quickstart_project`, and `setup_tests` to confirm decision ownership and non-interactive defaults remain consistent.
- Verify new tests in `tests/test_cli/` cover prompt ordering, no-op selection, and cancellation without over-mocking real behavior.
- Check `AGENTS.md` lifecycle ordering (`Commit -> Wrap-up -> Close`) for consistency with the always-on rules and skills index.
