### PR TITLE
docs(workflow): tighten builder approval and wrap-up lifecycle

### DIFF
--- a/.skills/github-issue-workflow/SKILL.md
+++ b/.skills/github-issue-workflow/SKILL.md
@@ -90,7 +90,9 @@ When `branch_mode` is `new`, derive the branch **before** substantive work:
 Post the chosen branch name in a short issue comment when first claiming (so humans see it before build):
 
 ```bash
-gh issue comment <num> --body "Branch: \`feat-my-slug\` (new — worktree)"
+gh issue comment <num> --body "Branch: \`feat-my-slug\` (new — worktree)
+
+🤖"
 ```
 
 ### Worktree for `new`

--- a/.skills/github-issue-workflow/SKILL.md
+++ b/.skills/github-issue-workflow/SKILL.md
@@ -7,6 +7,11 @@ description: "`gh` mechanics for the `agent:todo` issue lifecycle defined in thi
 
 Implements the lifecycle defined in [`AGENTS.md`](../../AGENTS.md) using GitHub Issues + the `gh` CLI. **This file is the playbook (how); AGENTS.md is the rulebook (what and why).** If they disagree, AGENTS.md wins.
 
+## Operating guardrails
+
+- In the face of uncertainty, refuse the temptation to guess and ask the user.
+- Every agent-authored issue comment or reply must end with `🤖` as the final non-whitespace character.
+
 ## Pre-flight: `gh`
 
 The user must have the `gh` CLI installed and authenticated.
@@ -128,6 +133,25 @@ gh issue edit <num> \
 
 `gh` silently ignores `--remove-label` entries that are not present, so the same remove-list is safe for every transition. **Never include `agent:todo` in the remove list** — the type label is preserved across the lifecycle.
 
+## Builder grill approval gate (before implementation)
+
+After a plan is approved and before code changes:
+
+1. Builder runs `/grill-with-docs` and updates the managed comment with:
+   - `Grill outcomes`
+   - `Open questions (async scout)` (if any remain)
+   - `Approval gate`
+   - `Build authorization`
+2. Transition issue to `agent:blocked` while waiting for explicit user build approval.
+3. Ask for explicit approval to proceed.
+4. Accept only explicit approval intents such as:
+   - `approved to build`
+   - `proceed to build`
+   - `go implement now`
+5. If phrasing is ambiguous or outside this allowlist, ask again. Do not infer intent.
+6. While waiting, send one concise reminder only; do not auto-proceed on timeout.
+7. Move to `agent:building` only after explicit approval.
+
 ## Managed plan comment
 
 Exactly one agent-owned comment per issue, bracketed by stable markers:
@@ -146,7 +170,33 @@ Exactly one agent-owned comment per issue, bracketed by stable markers:
 - Last updated: <ISO date>
 - Commit: <hash> (when applicable)
 
+### Grill outcomes
+
+- Decisions confirmed:
+- Assumptions challenged:
+- Risks noted:
+
+### Open questions (async scout)
+
+- Question:
+  - Recommended answer:
+  - Risk if wrong:
+  - Needs user confirmation:
+
+### Approval gate
+
+- Builder grill completed: yes | no
+- Awaiting explicit build approval: yes | no
+
+### Build authorization
+
+- Approval phrase:
+- Approved by:
+- Approved at:
+
 <!-- agent-plan:end -->
+
+🤖
 ```
 
 ### Find an existing managed comment
@@ -185,6 +235,8 @@ The managed comment **must** be up to date at:
 5. After merge, before close (final status + merge commit hash).
 
 Between checkpoints, prefer local drafts in `plans/scouting-<slug>.md` or `plans/building-<slug>.md` to limit `gh` traffic.
+
+For any non-managed issue comment (questions, status notes, branch announcements), append `🤖` as the final non-whitespace character.
 
 ## Wrap-up integration (post-merge close-out)
 

--- a/.skills/github-issue-workflow/SKILL.md
+++ b/.skills/github-issue-workflow/SKILL.md
@@ -38,7 +38,7 @@ No status label means the issue is **unclaimed**.
 | `agent:building`  | A builder is implementing; one per session                          |
 | `agent:blocked`   | Paused awaiting user input or external dependency                   |
 | `agent:reviewing` | Implementation done, awaiting critique/feedback before commit       |
-| `agent:done`      | Committed and ready to close (or already closed)                    |
+| `agent:done`      | PR merged; post-merge issue finalization complete (or already closed) |
 
 ### Bootstrap (one-time per repo)
 
@@ -48,7 +48,7 @@ gh label create "agent:scouting"  --color a2eeef --description "Agent status: sc
 gh label create "agent:building"  --color fbca04 --description "Agent status: building (implementation in progress)"
 gh label create "agent:blocked"   --color d73a4a --description "Agent status: blocked (awaiting user or external)"
 gh label create "agent:reviewing" --color 0075ca --description "Agent status: reviewing (critique pending)"
-gh label create "agent:done"      --color cfd3d7 --description "Agent status: done (committed, ready to close)"
+gh label create "agent:done"      --color cfd3d7 --description "Agent status: done (merged and closed)"
 ```
 
 ## Branch (required on every agent TODO)
@@ -182,12 +182,18 @@ The managed comment **must** be up to date at:
 2. Start of build (plan confirmed).
 3. End of build, before commit (critique + verification summary).
 4. After commit (final status + commit hash).
+5. After merge, before close (final status + merge commit hash).
 
 Between checkpoints, prefer local drafts in `plans/scouting-<slug>.md` or `plans/building-<slug>.md` to limit `gh` traffic.
 
-## Closing an issue
+## Wrap-up integration (post-merge close-out)
 
-After commit:
+Keep `agent:building` during PR open, CI, and merge. After PR merge succeeds, run this close-out sequence:
+
+1. Resolve linked issue from the branch work item (`Refs #<num>` convention; avoid `Closes #<num>` automation).
+2. Update the managed comment one last time with `Phase: done` and `Commit: <merge_sha>`.
+3. Transition status labels to `agent:done` (removing other `agent:*` status labels).
+4. Close the issue as completed.
 
 ```bash
 gh issue edit <num> \
@@ -196,7 +202,9 @@ gh issue edit <num> \
 gh issue close <num> --reason completed
 ```
 
-Update the managed comment one last time with `Commit: <hash>` in the Status block before closing. The `agent:todo` label remains on the closed issue (useful for `gh issue list --state closed --label agent:todo`).
+## Closing an issue
+
+Only close after merge has succeeded and the post-merge close-out sequence above is complete. The `agent:todo` label remains on the closed issue (useful for `gh issue list --state closed --label agent:todo`).
 
 ## Conflict resolution
 
@@ -205,7 +213,7 @@ GitHub state wins (AGENTS.md rule 6). Edge cases:
 | Conflict                                       | Resolution                                |
 | ---------------------------------------------- | ----------------------------------------- |
 | Two managed comments found on one issue        | Stop. Ask user which to keep.             |
-| Local `plans/built-*.md` but issue still open  | Sync: close the issue with commit info.   |
+| Local `plans/built-*.md` but issue still open  | Sync post-merge: update issue with merge hash, set `agent:done`, close. |
 | Local `plans/scouted-*.md` but no issue exists | Ask whether to create the issue.          |
 
 ## `gh` cheat sheet
@@ -220,6 +228,7 @@ GitHub state wins (AGENTS.md rule 6). Edge cases:
 | Atomic label transition       | `gh issue edit <num> --add-label "<a>" --remove-label "<b>,<c>"`                                      |
 | Create plan comment           | `gh issue comment <num> --body-file plan.md`                                                          |
 | Edit comment in place         | `gh api --method PATCH /repos/<o>/<r>/issues/comments/<id> -f body="$(cat plan.md)"`                  |
+| Post-merge close-out          | `gh issue edit <num> --add-label "agent:done" --remove-label "agent:scouting,agent:building,agent:blocked,agent:reviewing" && gh issue close <num> --reason completed` |
 | Close as completed            | `gh issue close <num> --reason completed`                                                             |
 | Check repo visibility         | `gh repo view --json visibility`                                                                      |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,12 +15,13 @@ Every work item follows the same cycle:
 3. **Optional clarification** with the user.
 4. **Optional scout** — produce a plan in the issue's managed comment without implementation changes.
 5. **Plan approval** — get explicit user go-ahead before implementing.
-6. **Build** — implement.
-7. **Critique & feedback** — summarize what changed, what was verified, residual risks.
-8. **Adversarial review** - Spawn a sub-agent whose explicit task is to adversarially review the implementation and assess security risks
-9. **Commit** — one issue = one commit, conventional message, `Refs #<num>` in the footer.
-10. **Wrap-up** — when implementation is done, run the `/wrap-up-branch` skill through PR merge. Keep `agent:building` during PR/CI/wrap-up.
-11. **Close (post-merge)** — after merge succeeds, update the issue status with the merge commit hash, switch label to `agent:done`, and close the issue.
+6. **Builder grill gate** — builder runs `/grill-with-docs`, records outcomes/open questions, then explicitly asks permission to proceed. While waiting, keep the issue in `agent:blocked`.
+7. **Build** — implement only after explicit user approval to build.
+8. **Critique & feedback** — summarize what changed, what was verified, residual risks.
+9. **Adversarial review** - Spawn a sub-agent whose explicit task is to adversarially review the implementation and assess security risks
+10. **Commit** — one issue = one commit, conventional message, `Refs #<num>` in the footer.
+11. **Wrap-up** — when implementation is done, run the `/wrap-up-branch` skill through PR merge. Keep `agent:building` during PR/CI/wrap-up.
+12. **Close (post-merge)** — after merge succeeds, update the issue status with the merge commit hash, switch label to `agent:done`, and close the issue.
 
 ## Always-on rules
 
@@ -32,6 +33,8 @@ Every work item follows the same cycle:
 6. **GitHub state wins.** When the issue and any local artifact (e.g. `plans/`) disagree, the issue is correct.
 7. **Never publish secrets** into issue bodies or comments — tokens, `.env` contents, `gh auth token` output, credentials, PII, customer data. Treat issues as world-readable until proven otherwise.
 8. **Use wrap-up skill before close.** Follow lifecycle order: run `/wrap-up-branch` after commit/critique and before closing the issue. Wrap-up is not complete until the linked issue is transitioned to `agent:done` and closed.
+9. **Refuse guessing under uncertainty.** In the face of uncertainty, refuse the temptation to guess and ask the user.
+10. **Mark agent-authored issue content.** Every agent-authored issue comment/reply must end with `🤖` as the final non-whitespace character.
 
 ## Worktrees
 
@@ -55,7 +58,9 @@ When multiple scout sub-agents run in parallel, each scout must follow this inte
 - **Branch baseline first.** Scout from the branch declared in the issue body. If no valid branch is declared, default to `main` and explicitly note that fallback in the managed comment.
 - **Worktree when not on main.** If the effective scouting branch is not `main`, use a dedicated worktree for that scout.
 - **Mandatory grilling.** Use the `/grill-with-docs` skill during scouting.
-- **One question at a time.** Ask exactly one clarifying question, include a recommended answer, then stop and wait for the user before continuing.
+- **Asynchronous scouting is allowed.** If user attention is unavailable, do not block scouting; publish unresolved items under `Open questions (async scout)` in the managed comment.
+- **Structured unresolved items.** Each unresolved scouting question must include: `Question`, `Recommended answer`, `Risk if wrong`, `Needs user confirmation`.
+- **One question at a time (live mode).** When actively interviewing the user, ask exactly one clarifying question, include a recommended answer, then wait for the user before continuing.
 - **Track Q&A in GitHub.** Every question/answer turn must be appended to the issue's managed comment so the issue remains the source of truth.
 - **Stay read-only.** Question loops are scouting only: no implementation, docs, or test edits.
 
@@ -65,6 +70,8 @@ If the next pickup is a scouted issue:
 
 - Start from the managed plan comment.
 - **Do not run to build.** The scout did not verify against the live repo; iterate the plan with the user first.
+- **Builder grill is mandatory.** Before implementation, builder must run `/grill-with-docs`, publish `Grill outcomes`, then explicitly ask for build authorization.
+- **Strict approval gate.** If approval wording is ambiguous, do not infer intent; ask again. No implementation starts before explicit approval.
 - If another scout is currently running (`agent:scouting`) on the issue you want, ask the user: wait, take a different issue, or stop.
 
 ## Skills index

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,8 +19,8 @@ Every work item follows the same cycle:
 7. **Critique & feedback** — summarize what changed, what was verified, residual risks.
 8. **Adversarial review** - Spawn a sub-agent whose explicit task is to adversarially review the implementation and assess security risks
 9. **Commit** — one issue = one commit, conventional message, `Refs #<num>` in the footer.
-10. **Wrap-up** — when implementation is done, run the `/wrap-up-branch` skill to finalize branch readiness.
-11. **Close** — update the issue with the commit hash, switch label to `agent:done`, close the issue.
+10. **Wrap-up** — when implementation is done, run the `/wrap-up-branch` skill through PR merge. Keep `agent:building` during PR/CI/wrap-up.
+11. **Close (post-merge)** — after merge succeeds, update the issue status with the merge commit hash, switch label to `agent:done`, and close the issue.
 
 ## Always-on rules
 
@@ -28,10 +28,10 @@ Every work item follows the same cycle:
 2. **One build at a time.** At most one issue may have `agent:building` per session. If the user asks for a second concurrent build, stop and ask what to do.
 3. **Don't steal claims.** If `agent:scouting` or `agent:building` is already set by another agent, stop and ask the user.
 4. **One issue = one commit** with a clear conventional commit message. Reference the issue (`Refs #<num>`) in the commit footer.
-5. **Plans live in the issue's managed comment.** Local drafts in `plans/` are allowed for noisy iteration but must be published to the comment at four checkpoints: end of scouting, start of build, before commit, after commit.
+5. **Plans live in the issue's managed comment.** Local drafts in `plans/` are allowed for noisy iteration but must be published to the comment at four checkpoints: end of scouting, start of build, before commit, after commit. For merged PRs, publish a final post-merge status update before closing.
 6. **GitHub state wins.** When the issue and any local artifact (e.g. `plans/`) disagree, the issue is correct.
 7. **Never publish secrets** into issue bodies or comments — tokens, `.env` contents, `gh auth token` output, credentials, PII, customer data. Treat issues as world-readable until proven otherwise.
-8. **Use wrap-up skill before close.** Follow lifecycle order: run `/wrap-up-branch` after commit/critique and before closing the issue.
+8. **Use wrap-up skill before close.** Follow lifecycle order: run `/wrap-up-branch` after commit/critique and before closing the issue. Wrap-up is not complete until the linked issue is transitioned to `agent:done` and closed.
 
 ## Worktrees
 
@@ -69,7 +69,7 @@ If the next pickup is a scouted issue:
 
 ## Skills index
 
-- [`.skills/github-issue-workflow/SKILL.md`](.skills/github-issue-workflow/SKILL.md) — `gh` mechanics for the `agent:todo` issue lifecycle: claiming, managed plan comments, label transitions.
+- [`.skills/github-issue-workflow/SKILL.md`](.skills/github-issue-workflow/SKILL.md) — `gh` mechanics for the `agent:todo` issue lifecycle: claiming, managed plan comments, label transitions, and post-merge close-out.
 - `/wrap-up-branch` — required end-of-task branch finalization workflow once implementation is complete.
 
 ## Local artifacts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ Every work item follows the same cycle:
 2. **One build at a time.** At most one issue may have `agent:building` per session. If the user asks for a second concurrent build, stop and ask what to do.
 3. **Don't steal claims.** If `agent:scouting` or `agent:building` is already set by another agent, stop and ask the user.
 4. **One issue = one commit** with a clear conventional commit message. Reference the issue (`Refs #<num>`) in the commit footer.
-5. **Plans live in the issue's managed comment.** Local drafts in `plans/` are allowed for noisy iteration but must be published to the comment at four checkpoints: end of scouting, start of build, before commit, after commit. For merged PRs, publish a final post-merge status update before closing.
+5. **Plans live in the issue's managed comment.** Local drafts in `plans/` are allowed for noisy iteration but must be published to the comment at the required lifecycle checkpoints (see the workflow docs). For merged PRs, publish a final post-merge status update before closing.
 6. **GitHub state wins.** When the issue and any local artifact (e.g. `plans/`) disagree, the issue is correct.
 7. **Never publish secrets** into issue bodies or comments — tokens, `.env` contents, `gh auth token` output, credentials, PII, customer data. Treat issues as world-readable until proven otherwise.
 8. **Use wrap-up skill before close.** Follow lifecycle order: run `/wrap-up-branch` after commit/critique and before closing the issue. Wrap-up is not complete until the linked issue is transitioned to `agent:done` and closed.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -41,3 +41,12 @@ The stable public surface for running `siesta` as a command. Behavior and comman
 
 ### Secret Handling Policy
 The rules governing how credential material may enter and leave the CLI: secrets are not accepted via command-line arguments, and plaintext secret output requires explicit interactive confirmation.
+
+### Wrap-Up Phase
+The post-commit, pre-close phase where branch work is finalized through PR validation and merge while the issue remains in an active building state.
+
+### Post-Merge Finalization
+The mandatory issue-close sequence that occurs only after merge succeeds: publish final issue status, transition to `agent:done`, and close the issue.
+
+### Issue Reference Convention
+The rule that branch commits and PR context use `Refs #<num>` for linkage; issue closure remains an explicit workflow step rather than auto-close keywords.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -45,6 +45,9 @@ The rules governing how credential material may enter and leave the CLI: secrets
 ### Wrap-Up Phase
 The post-commit, pre-close phase where branch work is finalized through PR validation and merge while the issue remains in an active building state.
 
+### Builder Grill Gate
+The required pre-build checkpoint where the builder runs `/grill-with-docs`, records grill outcomes and open questions, then requests explicit build authorization. While awaiting approval, the issue remains `agent:blocked`; implementation starts only after explicit authorization.
+
 ### Post-Merge Finalization
 The mandatory issue-close sequence that occurs only after merge succeeds: publish final issue status, transition to `agent:done`, and close the issue.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,12 +43,15 @@ flowchart TD
     end
 
     subgraph build["Build"]
-        G -->|no / after approval| M["Claim: agent:building"]
+        G -->|no| M[Builder runs /grill-with-docs]
         K -->|yes| M
-        M --> N[Implement on declared branch]
-        N --> O["agent:reviewing — critique + adversarial review"]
-        O --> P[One commit with Refs #N]
-        P --> W["Wrap-up: PR, CI, merge (keep agent:building)"]
+        M --> N[Publish grill outcomes + ask build authorization]
+        N --> O["agent:blocked — await explicit build authorization"]
+        O -->|approved| P["Claim: agent:building"]
+        P --> Q[Implement on declared branch]
+        Q --> R1["agent:reviewing — critique + adversarial review"]
+        R1 --> S1[One commit with Refs #N]
+        S1 --> W["Wrap-up: PR, CI, merge (keep agent:building)"]
         W --> X["agent:done + close issue (post-merge)"]
     end
 
@@ -161,8 +164,9 @@ Local files under `plans/` are drafts only; **the issue comment is the source of
 
 **Building**:
 
-- Starts only after explicit plan approval (or when scouting was skipped).
-- Builder claims `agent:building`, implements, runs critique + adversarial review, commits, wraps up through PR merge, then finalizes close-out.
+- Starts only after the builder runs `/grill-with-docs`, publishes grill outcomes, and receives explicit build authorization.
+- If scouting is skipped, the same grill + explicit build authorization gate still applies before claiming `agent:building`.
+- After authorization, builder claims `agent:building`, implements, runs critique + adversarial review, commits, wraps up through PR merge, then finalizes close-out.
 
 If you pick up a **scouted** issue, start from the managed plan comment and **do not** jump straight to implementation — confirm the plan with the user first.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,8 @@ flowchart TD
         M --> N[Implement on declared branch]
         N --> O["agent:reviewing — critique + adversarial review"]
         O --> P[One commit with Refs #N]
-        P --> Q["agent:done + close issue"]
+        P --> W["Wrap-up: PR, CI, merge (keep agent:building)"]
+        W --> X["agent:done + close issue (post-merge)"]
     end
 
     subgraph artifacts["Artifacts"]
@@ -81,7 +82,8 @@ stateDiagram-v2
 
     Building --> Reviewing: implementation done
     Reviewing --> Building: changes requested
-    Reviewing --> Done: commit pushed
+    Reviewing --> Building: commit pushed, wrap-up starts
+    Building --> Done: PR merged + issue finalized
 
     Done --> [*]: issue closed
 
@@ -105,7 +107,7 @@ stateDiagram-v2
 | `agent:blocked` | Paused — typically awaiting plan approval |
 | `agent:building` | Builder implementing (one build per agent session) |
 | `agent:reviewing` | Done coding; critique and security review before commit |
-| `agent:done` | Committed; issue ready to close or already closed |
+| `agent:done` | PR merged; issue finalized and closed (or already closed) |
 
 ## Branch and worktree
 
@@ -133,6 +135,7 @@ Each agent TODO has **exactly one** plan comment on the issue, marked with `<!--
 2. Start of build (plan confirmed)
 3. End of build, before commit (what changed, what was verified)
 4. After commit (final status + commit hash)
+5. After merge, before close (final status + merge commit hash)
 
 Local files under `plans/` are drafts only; **the issue comment is the source of truth**.
 
@@ -159,13 +162,13 @@ Local files under `plans/` are drafts only; **the issue comment is the source of
 **Building**:
 
 - Starts only after explicit plan approval (or when scouting was skipped).
-- Builder claims `agent:building`, implements, runs critique + adversarial review, commits, closes.
+- Builder claims `agent:building`, implements, runs critique + adversarial review, commits, wraps up through PR merge, then finalizes close-out.
 
 If you pick up a **scouted** issue, start from the managed plan comment and **do not** jump straight to implementation — confirm the plan with the user first.
 
 ## For agents
 
-Read [AGENTS.md](AGENTS.md) at session start. Use [`.skills/github-issue-workflow/SKILL.md`](.skills/github-issue-workflow/SKILL.md) for `gh` commands, label transitions, branch naming, and worktree setup.
+Read [AGENTS.md](AGENTS.md) at session start. Use [`.skills/github-issue-workflow/SKILL.md`](.skills/github-issue-workflow/SKILL.md) for `gh` commands, label transitions, branch naming, worktree setup, and post-merge issue finalization.
 
 **List open, unclaimed TODOs:**
 
@@ -184,5 +187,5 @@ gh label create "agent:scouting"  --color a2eeef --description "Agent status: sc
 gh label create "agent:building"  --color fbca04 --description "Agent status: building (implementation in progress)"
 gh label create "agent:blocked"   --color d73a4a --description "Agent status: blocked (awaiting user or external)"
 gh label create "agent:reviewing" --color 0075ca --description "Agent status: reviewing (critique pending)"
-gh label create "agent:done"      --color cfd3d7 --description "Agent status: done (committed, ready to close)"
+gh label create "agent:done"      --color cfd3d7 --description "Agent status: done (merged and closed)"
 ```


### PR DESCRIPTION
## TL;DR

Tighten the agent TODO workflow so issue finalization happens post-merge, and require an explicit builder grill-and-approval gate before implementation. Align `AGENTS.md`, the GitHub workflow skill, and contributor documentation around the same lifecycle and status semantics.

## Breaking changes 🔥

- **🟡 Process contract**: Agent workflow now requires explicit builder authorization after `/grill-with-docs` and before implementation. Existing operator habits that assumed plan approval alone is sufficient must adapt to the new gate.

## Changes

- **Post-merge close-out policy**: Define `agent:done` as post-merge finalization, keep `agent:building` through PR/CI/wrap-up, and require a final managed-comment publication before issue close.
- **Builder approval gate**: Add mandatory builder grilling, strict approval handling under ambiguity, and `agent:blocked` waiting semantics before build execution.
- **Scouting guidance**: Permit asynchronous scouting handoff with structured unresolved questions while keeping mandatory grilling.
- **Authorship attribution**: Require agent-authored issue comments to end with `🤖` for clear human-vs-agent distinction.
- **Docs alignment**: Update contributor diagrams/glossary and workflow examples so lifecycle labels and close-out behavior match the rulebook.

## Review hints

- Focus on consistency between `AGENTS.md` and `.skills/github-issue-workflow/SKILL.md` for lifecycle steps, status labels, and approval gate wording.
- Verify the contributor-facing flow in `CONTRIBUTING.md` reflects the same gate and post-merge close-out sequence as agent-facing docs.
- Confirm glossary entries in `CONTEXT.md` use domain language only and do not drift into implementation mechanics.
