### PR TITLE
Finalize agents-assets: constitution + review hardening

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,46 @@
 # Agents
 
-This repository coordinates agent work through **GitHub Issues as the shared source of truth**. Read this file at the start of every session.
+## Working Principles
+
+**Apply these universally, on every task.**
+
+### 1. Think Before Coding
+
+State your assumptions explicitly. If multiple interpretations exist, present them — don't pick silently. If a simpler approach exists, say so. If something is unclear, stop and ask.
+
+Read `system-architecture.md` first to understand repository structure and boundaries before broad searching. Treat it as the source of truth for architecture; when a task changes components, boundaries, or data flow, update it in the same task.
+
+Before implementing (and whenever a request is vague), use the `grill-with-docs` skill to stress-test the plan against the project's domain language and documented decisions (`CONTEXT.md`, ADRs).
+
+### 2. Simplicity First
+
+Minimum code that solves the problem. Nothing speculative. No features beyond what was asked, no abstractions for single-use code, no error handling for impossible scenarios.
+
+### 3. Surgical Changes
+
+Touch only what you must. Don't "improve" adjacent code, comments, or formatting. Match existing style. Every changed line should trace directly to the user's request. Remove imports/variables/functions that *your* changes made unused; leave pre-existing dead code alone.
+
+### 4. One Artifact Owns Each Piece of Guidance
+
+Three artifacts carry agent guidance, each owning a distinct slice:
+
+- **Constitution** (`AGENTS.md`): always loaded, applies to every task. Owns global principles only. Keep it thin.
+- **Rule** (`.cursor/rules/*.mdc`, `.claude/rules/*.md`): loaded by file glob/path. Owns constraints tied to a specific technology or directory.
+- **Skill** (`SKILL.md` directory): invoked on demand. Owns multi-step procedures and workflows.
+
+Never duplicate guidance across artifacts. When guidance is a procedure, move it into a Skill and reference it from here.
+
+### 5. Security and Consistency
+
+Treat secrets exposure as critical: API keys, tokens, passwords, credentials, webhook URLs, `.env` contents. Never hardcode secrets in code, tests, docs, examples, commits, or PR text. If you detect a leak or high-risk pattern, stop and warn clearly — even when it is outside the original request.
+
+Before declaring completion: (1) run a secret/leak/security scan, (2) verify every changed line traces to the user's request, (3) check consistency against `CONTEXT.md`, `CONTEXT-MAP.md`, and relevant ADRs.
+
+---
+
+## GitHub Issue Workflow
+
+This repository coordinates agent work through **GitHub Issues as the shared source of truth**.
 
 For the `gh` mechanics that implement this discipline (labels, managed-comment markers, command syntax), follow [`.skills/github-issue-workflow/SKILL.md`](.skills/github-issue-workflow/SKILL.md).
 

--- a/src/siesta/cli/agents_app.py
+++ b/src/siesta/cli/agents_app.py
@@ -193,9 +193,7 @@ def add_rule(
     providers = resolve_providers(cursor, claude, both)
 
     available = available_rules()
-    selected = resolve_selection(
-        list(names), all_, available, interactive, kind="rule"
-    )
+    selected = resolve_selection(list(names), all_, available, interactive, kind="rule")
     if not selected:
         logger.info("No rules selected; nothing to do.")
         sys.exit(0)
@@ -285,9 +283,7 @@ def add_constitution(
 
     available = available_constitutions()
     if name not in available:
-        logger.abort(
-            f"Unknown constitution: {name!r}. Available: {available}"
-        )
+        logger.abort(f"Unknown constitution: {name!r}. Available: {available}")
 
     # --- Execution phase ---
     summary = install_constitution(

--- a/src/siesta/cli/project_app.py
+++ b/src/siesta/cli/project_app.py
@@ -303,7 +303,11 @@ def quickstart_project(
         )
 
     if agents:
-        summary = install_quickstart(["cursor", "claude"], "local", force=overwrite)
+        # Back up existing agent files when overwriting so a user-authored
+        # CLAUDE.md/AGENTS.md is recoverable from a .bak.
+        summary = install_quickstart(
+            ["cursor", "claude"], "local", force=overwrite, backup=overwrite
+        )
         print_summary(summary)
         logger.info("Agent assets installed.")
 

--- a/src/siesta/cli/project_app.py
+++ b/src/siesta/cli/project_app.py
@@ -211,9 +211,7 @@ def quickstart_project(
         docs = logger.confirm("Would you like to initialize the docs?")
 
     if agents is None:
-        agents = logger.confirm(
-            "Would you like to install recommended agent assets?"
-        )
+        agents = logger.confirm("Would you like to install recommended agent assets?")
 
     docs_with_uv: bool | None = None
     if docs and deps:

--- a/src/siesta/logger.py
+++ b/src/siesta/logger.py
@@ -274,9 +274,7 @@ class Logger(BaseLogger):
         KeyboardInterrupt
             If the prompt is cancelled (for example with Ctrl+C).
         """
-        response = questionary.select(
-            f"{self.prefix}{message}", choices=choices
-        ).ask()
+        response = questionary.select(f"{self.prefix}{message}", choices=choices).ask()
         if response is None:
             raise KeyboardInterrupt()
         return response

--- a/src/siesta/utils/agents.py
+++ b/src/siesta/utils/agents.py
@@ -496,9 +496,9 @@ def write_dir(
     action = _decide_action(dest, force, backup, interactive, display)
     if action == "skip":
         return "skip"
-    if action == "backup_write" and dest.exists():
+    if action == "backup_write":
         _apply_backup(dest)
-    elif action == "overwrite" and dest.exists():
+    elif action == "overwrite":
         shutil.rmtree(dest)
     dest.parent.mkdir(parents=True, exist_ok=True)
     shutil.copytree(str(src), str(dest))

--- a/src/siesta/utils/agents.py
+++ b/src/siesta/utils/agents.py
@@ -337,7 +337,12 @@ def resolve_selection(
         if unknown:
             logger.abort(f"Unknown {kind}(s): {unknown}. Available: {available}")
         return list(names)
-    if not (interactive or sys.stdin.isatty()):
+    # Interactive selection needs a real terminal, regardless of how it was
+    # requested. An explicit -i with no TTY is a broken invocation worth
+    # surfacing rather than letting questionary hang or crash.
+    if not sys.stdin.isatty():
+        if interactive:
+            logger.abort("Interactive selection requires a terminal (no TTY).")
         logger.abort(
             f"No {kind}s specified. Pass names, --all, or use -i for interactive mode."
         )

--- a/src/siesta/utils/agents.py
+++ b/src/siesta/utils/agents.py
@@ -6,6 +6,7 @@ rule translation, conflict-aware file writing, and the constitution install
 algorithm.
 """
 
+import json
 import shutil
 import sys
 from importlib.resources import files
@@ -212,6 +213,42 @@ def _split_frontmatter(text: str) -> tuple[dict, str]:
     return fm, body.lstrip("\n")
 
 
+def _split_globs(value: str) -> list[str]:
+    """Split a Cursor ``globs`` string into individual patterns.
+
+    Cursor uses commas to separate multiple globs, but a single brace-expansion
+    glob (e.g. ``**/*.{py,js}``) also contains commas. Split only on commas at
+    brace-nesting depth 0 so brace groups stay intact.
+
+    Parameters
+    ----------
+    value : str
+        Raw comma-separated ``globs`` value.
+
+    Returns
+    -------
+    list[str]
+        Individual glob patterns, stripped of surrounding whitespace.
+    """
+    patterns: list[str] = []
+    depth = 0
+    current = ""
+    for char in value:
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth = max(0, depth - 1)
+        if char == "," and depth == 0:
+            if current.strip():
+                patterns.append(current.strip())
+            current = ""
+        else:
+            current += char
+    if current.strip():
+        patterns.append(current.strip())
+    return patterns
+
+
 def mdc_to_claude(text: str) -> str:
     """Translate a Cursor ``.mdc`` rule to Claude ``.md`` format.
 
@@ -240,11 +277,17 @@ def mdc_to_claude(text: str) -> str:
     paths: list[str] | None = None
     if not always and globs:
         if isinstance(globs, str):
-            paths = [g.strip() for g in globs.split(",") if g.strip()]
+            paths = _split_globs(globs)
         elif isinstance(globs, list):
             paths = [str(g) for g in globs]
     if paths:
-        front = "---\npaths:\n" + "".join(f'  - "{p}"\n' for p in paths) + "---\n\n"
+        # json.dumps produces a valid double-quoted YAML scalar, escaping any
+        # quotes/backslashes a glob might contain.
+        front = (
+            "---\npaths:\n"
+            + "".join(f"  - {json.dumps(p)}\n" for p in paths)
+            + "---\n\n"
+        )
         return front + body
     return body
 

--- a/src/siesta/utils/agents.py
+++ b/src/siesta/utils/agents.py
@@ -57,9 +57,7 @@ def available_rules() -> list[str]:
     list[str]
         Sorted list of rule names.
     """
-    return sorted(
-        p.name[:-4] for p in RULES_DIR.iterdir() if p.name.endswith(".mdc")
-    )
+    return sorted(p.name[:-4] for p in RULES_DIR.iterdir() if p.name.endswith(".mdc"))
 
 
 def available_constitutions() -> list[str]:
@@ -294,9 +292,7 @@ def resolve_selection(
     if names:
         unknown = [n for n in names if n not in available]
         if unknown:
-            logger.abort(
-                f"Unknown {kind}(s): {unknown}. Available: {available}"
-            )
+            logger.abort(f"Unknown {kind}(s): {unknown}. Available: {available}")
         return list(names)
     if not (interactive or sys.stdin.isatty()):
         logger.abort(
@@ -630,7 +626,7 @@ def install_constitution(
         force=force,
         backup=backup,
         interactive=interactive,
-        label=f"AGENTS.md",
+        label="AGENTS.md",
     )
     _record(summary, action, str(agents_dest))
     if action != "skip":
@@ -707,9 +703,7 @@ def _handle_claude_import(
         )
 
     if do_prepend:
-        claude_dest.write_text(
-            f"{IMPORT_LINE}\n\n{existing}", encoding="utf-8"
-        )
+        claude_dest.write_text(f"{IMPORT_LINE}\n\n{existing}", encoding="utf-8")
         summary["written"].append(str(claude_dest) + " (import prepended)")
 
 
@@ -804,17 +798,28 @@ def install_quickstart(
     # Execution phase: install each category, merging results into one summary.
     combined: dict[str, list[str]] = {"written": [], "skipped": [], "backed_up": []}
     for name in cfg["skills"]:
-        result = install_skill(name, providers, scope, force=force, backup=backup, interactive=interactive)
+        result = install_skill(
+            name, providers, scope, force=force, backup=backup, interactive=interactive
+        )
         for key in combined:
             combined[key].extend(result.get(key, []))
 
     for name in cfg["rules"]:
-        result = install_rule(name, providers, scope, force=force, backup=backup, interactive=interactive)
+        result = install_rule(
+            name, providers, scope, force=force, backup=backup, interactive=interactive
+        )
         for key in combined:
             combined[key].extend(result.get(key, []))
 
     if cfg["constitution"]:
-        result = install_constitution(cfg["constitution"], providers, scope, force=force, backup=backup, interactive=interactive)
+        result = install_constitution(
+            cfg["constitution"],
+            providers,
+            scope,
+            force=force,
+            backup=backup,
+            interactive=interactive,
+        )
         for key in combined:
             combined[key].extend(result.get(key, []))
 

--- a/src/siesta/utils/agents.py
+++ b/src/siesta/utils/agents.py
@@ -14,10 +14,7 @@ from pathlib import Path
 
 from ruamel.yaml import YAML
 
-from siesta.logger import Logger
-
-logger = Logger("siesta")
-"""A logger to log messages to the console."""
+from siesta.utils.common import logger
 
 # ---------------------------------------------------------------------------
 # Catalog root

--- a/tests/test_cli/test_agents_app.py
+++ b/tests/test_cli/test_agents_app.py
@@ -8,13 +8,9 @@ are isolated.
 
 import sys
 from pathlib import Path
-from unittest.mock import patch
-
-import pytest
 
 from siesta.cli.main_app import app
-from siesta.utils.agents import DEFAULT_CONSTITUTION, IMPORT_LINE
-
+from siesta.utils.agents import IMPORT_LINE
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -62,14 +58,10 @@ class TestAddSkill:
 
         run("agents", "add-skill", "--all", "--cursor")
         for skill in available_skills():
-            assert (
-                tmp_path_chdir / ".cursor" / "skills" / skill
-            ).is_dir()
+            assert (tmp_path_chdir / ".cursor" / "skills" / skill).is_dir()
 
     def test_all_and_names_mutual_exclusion(self, tmp_path_chdir):
-        code = run(
-            "agents", "add-skill", "grill-with-docs", "--all", "--cursor"
-        )
+        code = run("agents", "add-skill", "grill-with-docs", "--all", "--cursor")
         assert code != 0
 
     def test_unknown_skill_name_aborts(self, tmp_path_chdir):
@@ -121,15 +113,11 @@ class TestAddSkill:
 class TestAddRule:
     def test_cursor_rule_is_mdc(self, tmp_path_chdir):
         run("agents", "add-rule", "python-docstrings", "--cursor")
-        assert (
-            tmp_path_chdir / ".cursor" / "rules" / "python-docstrings.mdc"
-        ).exists()
+        assert (tmp_path_chdir / ".cursor" / "rules" / "python-docstrings.mdc").exists()
 
     def test_claude_rule_is_md(self, tmp_path_chdir):
         run("agents", "add-rule", "python-docstrings", "--claude")
-        assert (
-            tmp_path_chdir / ".claude" / "rules" / "python-docstrings.md"
-        ).exists()
+        assert (tmp_path_chdir / ".claude" / "rules" / "python-docstrings.md").exists()
 
     def test_claude_rule_translated_has_paths(self, tmp_path_chdir):
         run("agents", "add-rule", "python-docstrings", "--claude")
@@ -151,9 +139,7 @@ class TestAddRule:
 
         run("agents", "add-rule", "--all", "--cursor")
         for rule in available_rules():
-            assert (
-                tmp_path_chdir / ".cursor" / "rules" / f"{rule}.mdc"
-            ).exists()
+            assert (tmp_path_chdir / ".cursor" / "rules" / f"{rule}.mdc").exists()
 
     def test_unknown_rule_aborts(self, tmp_path_chdir):
         code = run("agents", "add-rule", "nonexistent-rule", "--cursor")
@@ -240,9 +226,7 @@ class TestAddConstitution:
         assert (tmp_path_chdir / "AGENTS.md.bak").read_text() == "old agents"
 
     def test_local_and_global_abort(self, tmp_path_chdir):
-        code = run(
-            "agents", "add-constitution", "--local", "--global"
-        )
+        code = run("agents", "add-constitution", "--local", "--global")
         assert code != 0
 
 
@@ -254,7 +238,9 @@ class TestAddConstitution:
 class TestQuickstart:
     def test_quickstart_installs_all_both_local(self, tmp_path_chdir):
         run("agents", "quickstart", "--both", "--local")
-        assert (tmp_path_chdir / ".cursor" / "skills" / "grill-with-docs" / "SKILL.md").exists()
+        assert (
+            tmp_path_chdir / ".cursor" / "skills" / "grill-with-docs" / "SKILL.md"
+        ).exists()
         assert (tmp_path_chdir / ".cursor" / "rules" / "python-docstrings.mdc").exists()
         assert (tmp_path_chdir / ".claude" / "rules" / "mirror-providers.md").exists()
         assert (tmp_path_chdir / "AGENTS.md").exists()
@@ -262,7 +248,9 @@ class TestQuickstart:
 
     def test_quickstart_cursor_only(self, tmp_path_chdir):
         run("agents", "quickstart", "--cursor")
-        assert (tmp_path_chdir / ".cursor" / "skills" / "grill-with-docs" / "SKILL.md").exists()
+        assert (
+            tmp_path_chdir / ".cursor" / "skills" / "grill-with-docs" / "SKILL.md"
+        ).exists()
         assert not (tmp_path_chdir / ".claude" / "skills").exists()
 
     def test_quickstart_force_overwrites(self, tmp_path_chdir):

--- a/tests/test_cli/test_cli_package.py
+++ b/tests/test_cli/test_cli_package.py
@@ -51,11 +51,7 @@ def _subapp_names(root_app: App) -> set[str]:
 
 def _command_names(root_app: App) -> set[str]:
     """Return user-facing command names registered on a Cyclopts app."""
-    return {
-        name
-        for name in root_app._commands
-        if not name.startswith("-")
-    }
+    return {name for name in root_app._commands if not name.startswith("-")}
 
 
 def test_root_app_registers_domain_apps():
@@ -93,7 +89,12 @@ def test_tab_completions_app_registers_leaf_commands():
 
 
 def test_agents_app_registers_commands():
-    assert _command_names(agents_app) == {"add-skill", "add-rule", "add-constitution", "quickstart"}
+    assert _command_names(agents_app) == {
+        "add-skill",
+        "add-rule",
+        "add-constitution",
+        "quickstart",
+    }
 
 
 def test_agents_app_exposes_command_callables():

--- a/tests/test_utils/test_agents.py
+++ b/tests/test_utils/test_agents.py
@@ -12,6 +12,7 @@ from siesta.utils.agents import (
     DEFAULT_CONSTITUTION,
     IMPORT_LINE,
     _split_frontmatter,
+    _split_globs,
     available_constitutions,
     available_rules,
     available_skills,
@@ -218,6 +219,39 @@ class TestMdcToClaude:
         assert "alwaysApply" not in result
         assert "description" not in result
 
+    def test_brace_glob_kept_intact(self):
+        # A single brace-expansion glob must not be split on its inner comma.
+        text = "---\nglobs: '**/*.{py,js}'\nalwaysApply: false\n---\n\n# Body"
+        result = mdc_to_claude(text)
+        fm, _ = _split_frontmatter(result)
+        assert fm["paths"] == ["**/*.{py,js}"]
+
+    def test_brace_glob_mixed_with_list(self):
+        # Top-level commas separate; brace groups stay intact.
+        text = "---\nglobs: 'a.py,**/*.{ts,tsx}'\nalwaysApply: false\n---\n\n# Body"
+        result = mdc_to_claude(text)
+        fm, _ = _split_frontmatter(result)
+        assert fm["paths"] == ["a.py", "**/*.{ts,tsx}"]
+
+    def test_glob_with_quote_is_valid_yaml(self):
+        # A glob containing a double-quote must round-trip as valid YAML.
+        weird = '**/*".py'
+        text = f"---\nglobs: '{weird}'\nalwaysApply: false\n---\n\n# Body"
+        result = mdc_to_claude(text)
+        fm, _ = _split_frontmatter(result)
+        assert fm["paths"] == [weird]
+
+
+class TestSplitGlobs:
+    def test_plain_comma_list(self):
+        assert _split_globs("a,b,c") == ["a", "b", "c"]
+
+    def test_brace_group_not_split(self):
+        assert _split_globs("**/*.{py,js}") == ["**/*.{py,js}"]
+
+    def test_strips_whitespace_and_drops_empties(self):
+        assert _split_globs(" a , , b ") == ["a", "b"]
+
 
 # ---------------------------------------------------------------------------
 # Selection resolution
@@ -252,6 +286,12 @@ class TestResolveSelection:
         monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
         with pytest.raises(SystemExit):
             resolve_selection([], False, ["a"], False, "rule")
+
+    def test_interactive_without_tty_aborts(self, monkeypatch):
+        # Explicit -i with no terminal must abort, not fall through to a prompt.
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+        with pytest.raises(SystemExit):
+            resolve_selection([], False, ["a"], True, "rule")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_utils/test_agents.py
+++ b/tests/test_utils/test_agents.py
@@ -155,7 +155,9 @@ class TestSplitFrontmatter:
         assert body == "# Hello\nworld"
 
     def test_parses_frontmatter(self):
-        text = "---\ndescription: foo\nglobs: '**/*.py'\nalwaysApply: false\n---\n\n# Body"
+        text = (
+            "---\ndescription: foo\nglobs: '**/*.py'\nalwaysApply: false\n---\n\n# Body"
+        )
         fm, body = _split_frontmatter(text)
         assert fm["description"] == "foo"
         assert fm["globs"] == "**/*.py"
@@ -176,7 +178,9 @@ class TestMdcToClaude:
         assert "# Body" in result
 
     def test_globs_string_becomes_paths_list(self):
-        text = "---\ndescription: x\nglobs: '**/*.py'\nalwaysApply: false\n---\n\n# Body"
+        text = (
+            "---\ndescription: x\nglobs: '**/*.py'\nalwaysApply: false\n---\n\n# Body"
+        )
         result = mdc_to_claude(text)
         assert "paths:" in result
         assert '"**/*.py"' in result
@@ -223,8 +227,11 @@ class TestMdcToClaude:
 class TestResolveSelection:
     def test_explicit_names(self):
         result = resolve_selection(
-            ["python-docstrings"], False, ["python-docstrings", "mirror-providers"],
-            False, "rule"
+            ["python-docstrings"],
+            False,
+            ["python-docstrings", "mirror-providers"],
+            False,
+            "rule",
         )
         assert result == ["python-docstrings"]
 
@@ -343,8 +350,12 @@ class TestInstallSkill:
         monkeypatch.chdir(tmp_path)
         summary = install_skill("grill-with-docs", ["cursor", "claude"], "local")
         assert len(summary["written"]) == 2
-        assert (tmp_path / ".cursor" / "skills" / "grill-with-docs" / "SKILL.md").exists()
-        assert (tmp_path / ".claude" / "skills" / "grill-with-docs" / "SKILL.md").exists()
+        assert (
+            tmp_path / ".cursor" / "skills" / "grill-with-docs" / "SKILL.md"
+        ).exists()
+        assert (
+            tmp_path / ".claude" / "skills" / "grill-with-docs" / "SKILL.md"
+        ).exists()
 
     def test_skips_existing_cursor(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
@@ -401,9 +412,7 @@ class TestInstallRule:
 class TestInstallConstitution:
     def test_both_providers_local(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
-        summary = install_constitution(
-            DEFAULT_CONSTITUTION, ["cursor", "claude"], "local"
-        )
+        install_constitution(DEFAULT_CONSTITUTION, ["cursor", "claude"], "local")
         assert (tmp_path / "AGENTS.md").exists()
         assert (tmp_path / "CLAUDE.md").exists()
         assert (tmp_path / "CLAUDE.md").read_text().strip() == IMPORT_LINE
@@ -422,9 +431,7 @@ class TestInstallConstitution:
 
     def test_global_cursor_only_warns_and_skips(self, tmp_path, monkeypatch):
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
-        summary = install_constitution(
-            DEFAULT_CONSTITUTION, ["cursor"], "global"
-        )
+        summary = install_constitution(DEFAULT_CONSTITUTION, ["cursor"], "global")
         assert not (tmp_path / "AGENTS.md").exists()
         assert summary["written"] == []
 
@@ -446,17 +453,13 @@ class TestInstallConstitution:
     def test_existing_agents_md_overwritten_with_force(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
         (tmp_path / "AGENTS.md").write_text("old")
-        install_constitution(
-            DEFAULT_CONSTITUTION, ["cursor"], "local", force=True
-        )
+        install_constitution(DEFAULT_CONSTITUTION, ["cursor"], "local", force=True)
         assert (tmp_path / "AGENTS.md").read_text() != "old"
 
     def test_existing_claude_md_already_has_import_no_op(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
         (tmp_path / "CLAUDE.md").write_text(f"{IMPORT_LINE}\n\nExtra content")
-        install_constitution(
-            DEFAULT_CONSTITUTION, ["claude"], "local"
-        )
+        install_constitution(DEFAULT_CONSTITUTION, ["claude"], "local")
         content = (tmp_path / "CLAUDE.md").read_text()
         assert content.count(IMPORT_LINE) == 1
 
@@ -511,7 +514,9 @@ class TestInstallQuickstart:
     def test_installs_all_kinds_both_local(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
         install_quickstart(["cursor", "claude"], "local")
-        assert (tmp_path / ".cursor" / "skills" / "grill-with-docs" / "SKILL.md").exists()
+        assert (
+            tmp_path / ".cursor" / "skills" / "grill-with-docs" / "SKILL.md"
+        ).exists()
         assert (tmp_path / ".cursor" / "rules" / "python-docstrings.mdc").exists()
         assert (tmp_path / ".claude" / "rules" / "mirror-providers.md").exists()
         assert (tmp_path / "AGENTS.md").exists()


### PR DESCRIPTION
## TL;DR

Finalizes the agents-assets work: rewrites the root `AGENTS.md` into a structured
constitution, and lands the hardening fixes surfaced by a full wrap-up review
(adversarial + security) of the agents-assets feature.

## Context

The bulk of the agents-assets feature (the `siesta agents` CLI, asset catalog,
skills/rules/constitutions, and tests) was committed directly to `main`
(`19d1a86`, `3b65436`, `03b81b5`). This PR carries the **remaining** changes plus
the fixes a retroactive review of those commits produced, so the whole feature
gets the review it would have had via PR.

## What's in this PR

### Constitution (`AGENTS.md`)
Restructures the root constitution into explicit **Working Principles** — Think
Before Coding, Simplicity First, Surgical Changes, One-Artifact-Owns-Each-Guidance
(Constitution / Rule / Skill), and Security & Consistency — while preserving the
existing GitHub Issue Workflow section.

### Hardening (from review)
- **Glob translation robustness** (`mdc_to_claude`): Cursor `globs` are now split on
  top-level commas only, so a brace-expansion glob like `**/*.{py,js}` stays intact
  instead of being shredded into two broken patterns. Emitted `paths` are escaped via
  `json.dumps`, so a glob containing a quote/backslash produces valid YAML.
  (Brace expansion is documented Claude `paths` syntax, so this isn't hypothetical.)
- **Interactive guard**: `-i` with no TTY now aborts with a clear message instead of
  letting the prompt hang or crash.
- **Quickstart safety net**: `project quickstart --overwrite` now backs up an existing
  user-authored `CLAUDE.md`/`AGENTS.md` to `.bak` before replacing it.
- **Cleanups**: `agents.py` uses the shared `utils.common` logger like every other
  module; redundant `dest.exists()` guards removed from `write_dir`.

### Tests
+7 regression tests covering brace globs, quote escaping, and the interactive-no-TTY
abort. Full suite: **316 passing**.

## Review notes
- Security review: **clean** (no Critical/High/Medium).
- One review suggestion — carrying `description` into the Claude `.md` frontmatter —
  was **investigated and rejected**: official docs confirm `description` is not a
  consumed field in Claude rule frontmatter, so ADR 0004's decision to drop it is
  correct on the merits.
