### PR TITLE
feat: nested agents add/remove commands + safe quickstart conflict resolution

### DIFF
--- a/.claude/skills/github-issue-workflow/SKILL.md
+++ b/.claude/skills/github-issue-workflow/SKILL.md
@@ -1,0 +1,295 @@
+---
+name: github-issue-workflow
+description: "`gh` mechanics for the `agent:todo` issue lifecycle defined in this repo's AGENTS.md: identify TODO issues via the `agent:todo` label, claim with mutually-exclusive status labels, maintain a single managed plan comment per issue, and transition state atomically. Use whenever the user asks to claim, scout, plan, build, sync, publish, or close agent-actionable GitHub issues."
+---
+
+# GitHub Issue Workflow
+
+Implements the lifecycle defined in [`AGENTS.md`](../../AGENTS.md) using GitHub Issues + the `gh` CLI. **This file is the playbook (how); AGENTS.md is the rulebook (what and why).** If they disagree, AGENTS.md wins.
+
+## Operating guardrails
+
+- In the face of uncertainty, refuse the temptation to guess and ask the user.
+- Every agent-authored issue comment or reply must end with `🤖` as the final non-whitespace character.
+
+## Pre-flight: `gh`
+
+The user must have the `gh` CLI installed and authenticated.
+
+1. Installation (if missing) -> test with `which gh`, if not found, install with https://github.com/cli/cli#installation
+2. Authentication -> test with `gh auth status`, tell the user to run `gh auth login` if user isn't logged-in. 
+
+## Label vocabulary
+
+Two orthogonal axes.
+
+### Type label (persistent)
+
+| Label        | Meaning                                                                                                              |
+| ------------ | -------------------------------------------------------------------------------------------------------------------- |
+| `agent:todo` | Issue is agent-actionable. Required for the workflow to apply. Persists across the lifecycle, including after close. |
+
+Issues without `agent:todo` are out of scope (bugs, human discussions, feature requests).
+
+**Create agent TODOs** with the [Agent TODO](.github/ISSUE_TEMPLATE/agent-todo.yml) issue template (template chooser → *Agent TODO*). It applies `agent:todo` automatically and requires branch intent.
+
+### Status labels (mutually exclusive, one at a time)
+
+No status label means the issue is **unclaimed**.
+
+| Label             | Meaning                                                             |
+| ----------------- | ------------------------------------------------------------------- |
+| `agent:scouting`  | A scout is preparing the plan; read-only except the plan comment    |
+| `agent:building`  | A builder is implementing; one per session                          |
+| `agent:blocked`   | Paused awaiting user input or external dependency                   |
+| `agent:reviewing` | Implementation done, awaiting critique/feedback before commit       |
+| `agent:done`      | PR merged; post-merge issue finalization complete (or already closed) |
+
+### Bootstrap (one-time per repo)
+
+```bash
+gh label create "agent:todo"      --color 0e8a16 --description "Agent: TODO (agent-actionable)"
+gh label create "agent:scouting"  --color a2eeef --description "Agent status: scouting (plan in progress)"
+gh label create "agent:building"  --color fbca04 --description "Agent status: building (implementation in progress)"
+gh label create "agent:blocked"   --color d73a4a --description "Agent status: blocked (awaiting user or external)"
+gh label create "agent:reviewing" --color 0075ca --description "Agent status: reviewing (critique pending)"
+gh label create "agent:done"      --color cfd3d7 --description "Agent status: done (merged and closed)"
+```
+
+## Branch (required on every agent TODO)
+
+Every `agent:todo` issue must declare where work happens. Issues filed via the Agent TODO template include form fields **`Branch`** (`branch_mode`) and **`Existing branch name`** (`branch_name`). For issues created another way, the body must state the same information explicitly.
+
+| `branch_mode` | Meaning | Agent action |
+| ------------- | ------- | ------------ |
+| `new` | New work on a fresh branch | Derive branch name (below), create branch from default branch, work in a **worktree** |
+| `existing` | More work on a branch that already exists | Check out that branch (worktree if the user's setup uses them); **do not** create a new branch |
+
+### Pickup gate
+
+Before claiming, read the issue body (or `gh issue view <num> --json body`):
+
+1. If **`Branch`** is missing, **stop** — ask the user to add branch intent or re-file with the Agent TODO template.
+2. If **`Branch`** is `existing` and **`Existing branch name`** is empty, **stop** — ask the user to fill the branch name.
+3. If **`Branch`** is `existing`, verify the branch exists: `git ls-remote --heads origin <branch_name>` (or ask the user if offline).
+
+Record the resolved branch in the managed plan **Status** block (`Branch: …`).
+
+### New branch naming
+
+When `branch_mode` is `new`, derive the branch **before** substantive work:
+
+1. Start from the issue title: strip a leading `[agent todo]` (case-insensitive), lowercase, replace non-alphanumerics with `-`, collapse repeated hyphens, trim hyphens, truncate slug to **48** characters.
+2. Prefix by intent (default **`feat`**):
+   - `fix-` — bugfix / regression
+   - `docs-` — documentation only
+   - `chore-` — tooling, CI, repo hygiene
+   - `feat-` — everything else
+3. Final form: `<prefix>-<slug>` (e.g. `feat-add-agent-todo-template`). No slashes; match existing repo branches like `feat-agentic-research-workflow`.
+
+Post the chosen branch name in a short issue comment when first claiming (so humans see it before build):
+
+```bash
+gh issue comment <num> --body "Branch: \`feat-my-slug\` (new — worktree)
+
+🤖"
+```
+
+### Worktree for `new`
+
+When `branch_mode` is `new`, implement in a **separate worktree**, not the main checkout (AGENTS.md *Worktrees*):
+
+```bash
+# From repo root; adjust default branch if not main
+git fetch origin main
+SLUG="my-slug"   # from naming steps above, without prefix
+BRANCH="feat-${SLUG}"
+WT="../$(basename "$PWD")-${SLUG}"
+git worktree add -b "$BRANCH" "$WT" origin/main
+cd "$WT"
+```
+
+If the user does not use worktrees, or worktrees live elsewhere, **ask** before falling back to an in-place branch checkout.
+
+For `existing`, prefer a worktree on that branch when one already exists; otherwise `git worktree add <path> <branch_name>` or checkout per user preference.
+
+## Claim and state transitions
+
+Before claiming, inspect the issue:
+
+```bash
+gh issue view <num> --json number,title,labels,assignees,state,body
+```
+
+Run the **pickup gate** (branch fields) before setting a status label.
+
+If another agent's `agent:scouting` or `agent:building` is present, **stop and ask the user** (per AGENTS.md rule 3).
+
+Every status change is a single atomic `gh issue edit`:
+
+```bash
+gh issue edit <num> \
+  --add-label "agent:<new_status>" \
+  --remove-label "agent:scouting,agent:building,agent:blocked,agent:reviewing,agent:done"
+```
+
+`gh` silently ignores `--remove-label` entries that are not present, so the same remove-list is safe for every transition. **Never include `agent:todo` in the remove list** — the type label is preserved across the lifecycle.
+
+## Builder grill approval gate (before implementation)
+
+After a plan is approved and before code changes:
+
+1. Builder runs `/grill-with-docs` and updates the managed comment with:
+   - `Grill outcomes`
+   - `Open questions (async scout)` (if any remain)
+   - `Approval gate`
+   - `Build authorization`
+2. Transition issue to `agent:blocked` while waiting for explicit user build approval.
+3. Ask for explicit approval to proceed.
+4. Accept approval when the user provides an explicitly affirmative intent containing verb language rooted in `build` or `implement` (including standard inflections like `building`, `implemented`).
+5. Treat non-affirmative, speculative, or conditional wording as non-approval (for example: "maybe build", "we could implement later", "if tests pass then build").
+6. If approval is ambiguous, ask one direct confirmation question and do not infer intent.
+7. While waiting, send one concise reminder only; do not auto-proceed on timeout.
+8. Move to `agent:building` only after explicit approval.
+
+## Managed plan comment
+
+Exactly one agent-owned comment per issue, bracketed by stable markers:
+
+```markdown
+<!-- agent-plan:start -->
+
+## Plan
+
+<scouting or building plan>
+
+### Status
+
+- Phase: scouting | building | reviewing | done
+- Branch: <name> (`new` | `existing` per issue)
+- Last updated: <ISO date>
+- Commit: <hash> (when applicable)
+
+### Grill outcomes
+
+- Decisions confirmed:
+- Assumptions challenged:
+- Risks noted:
+
+### Open questions (async scout)
+
+- Question:
+  - Recommended answer:
+  - Risk if wrong:
+  - Needs user confirmation:
+
+### Approval gate
+
+- Builder grill completed: yes | no
+- Awaiting explicit build approval: yes | no
+
+### Build authorization
+
+- Approval phrase:
+- Approved by:
+- Approved at:
+
+<!-- agent-plan:end -->
+
+🤖
+```
+
+### Find an existing managed comment
+
+```bash
+gh issue view <num> --json comments \
+  --jq '.comments[] | select(.body | contains("<!-- agent-plan:start -->")) | {id, url}'
+```
+
+### Create the first time
+
+```bash
+gh issue comment <num> --body-file plan.md
+```
+
+### Edit in place
+
+`gh` has no `comment --edit`. Use the REST API:
+
+```bash
+gh api --method PATCH \
+  /repos/<owner>/<repo>/issues/comments/<comment_id> \
+  -f body="$(cat plan.md)"
+```
+
+If you cannot reliably find the prior managed comment, **stop and ask** — never post a duplicate plan comment.
+
+## Publication checkpoints
+
+The managed comment **must** be up to date at:
+
+1. End of scouting (plan ready for user review).
+2. Start of build (plan confirmed).
+3. End of build, before commit (critique + verification summary).
+4. After commit (final status + commit hash).
+5. After merge, before close (final status + merge commit hash).
+
+Keep checkpoint updates concise. At each checkpoint, update only fields that changed (phase, branch, timestamps, approvals, commit/merge hash, and short risks/findings deltas). Between checkpoints, prefer local drafts in `plans/scouting-<slug>.md` or `plans/building-<slug>.md` to limit `gh` traffic.
+
+For any non-managed issue comment (questions, status notes, branch announcements), append `🤖` as the final non-whitespace character.
+
+## Wrap-up integration (post-merge close-out)
+
+Keep `agent:building` during PR open, CI, and merge. After PR merge succeeds, run this close-out sequence:
+
+1. Resolve linked issue from the branch work item (`Refs #<num>` convention; avoid `Closes #<num>` automation).
+2. Update the managed comment one last time with `Phase: done` and `Commit: <merge_sha>`.
+3. Transition status labels to `agent:done` (removing other `agent:*` status labels).
+4. Close the issue as completed.
+
+```bash
+gh issue edit <num> \
+  --add-label "agent:done" \
+  --remove-label "agent:scouting,agent:building,agent:blocked,agent:reviewing"
+gh issue close <num> --reason completed
+```
+
+## Closing an issue
+
+Only close after merge has succeeded and the post-merge close-out sequence above is complete. The `agent:todo` label remains on the closed issue (useful for `gh issue list --state closed --label agent:todo`).
+
+## Conflict resolution
+
+GitHub state wins (AGENTS.md rule 6). Edge cases:
+
+| Conflict                                       | Resolution                                |
+| ---------------------------------------------- | ----------------------------------------- |
+| Two managed comments found on one issue        | Stop. Ask user which to keep.             |
+| Local `plans/built-*.md` but issue still open  | Sync post-merge: update issue with merge hash, set `agent:done`, close. |
+| Local `plans/scouted-*.md` but no issue exists | Ask whether to create the issue.          |
+
+## `gh` cheat sheet
+
+| Need                          | Command                                                                                               |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------- |
+| List open unclaimed           | `gh issue list --state open --label "agent:todo" --search "-label:agent:scouting -label:agent:building -label:agent:blocked -label:agent:reviewing"` |
+| Read branch fields            | `gh issue view <num> --json body --jq .body` (look for `### Branch` / `### Existing branch name`) |
+| Verify remote branch exists   | `git ls-remote --heads origin <branch_name>`                                                          |
+| List all agent-completed work | `gh issue list --state closed --label "agent:todo" --label "agent:done"`                              |
+| Show issue + all comments     | `gh issue view <num> --comments`                                                                      |
+| Atomic label transition       | `gh issue edit <num> --add-label "<a>" --remove-label "<b>,<c>"`                                      |
+| Create plan comment           | `gh issue comment <num> --body-file plan.md`                                                          |
+| Edit comment in place         | `gh api --method PATCH /repos/<o>/<r>/issues/comments/<id> -f body="$(cat plan.md)"`                  |
+| Post-merge close-out          | `gh issue edit <num> --add-label "agent:done" --remove-label "agent:scouting,agent:building,agent:blocked,agent:reviewing" && gh issue close <num> --reason completed` |
+| Close as completed            | `gh issue close <num> --reason completed`                                                             |
+| Check repo visibility         | `gh repo view --json visibility`                                                                      |
+
+## Security (gh-specific)
+
+AGENTS.md rule 7 forbids publishing secrets. Concrete gh-specific guardrails:
+
+- **Never paste** `gh auth token` output, `Authorization:` headers, `.env` contents, API keys, signed URLs, or session cookies into issue bodies or comments.
+- **Avoid absolute local paths** in comments; use repo-relative paths.
+- **Sanitize logs and tracebacks** before pasting — strip credentials, IPs, hostnames, customer/PII data.
+- **Check `gh repo view --json visibility`** before pasting implementation detail into a comment you would not put in a public README.
+- If you find pre-existing secrets in an issue or comment, **stop and warn the user** instead of silently editing.

--- a/.claude/skills/github-issue-workflow/SKILL.md
+++ b/.claude/skills/github-issue-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github-issue-workflow
-description: "`gh` mechanics for the `agent:todo` issue lifecycle defined in this repo's AGENTS.md: identify TODO issues via the `agent:todo` label, claim with mutually-exclusive status labels, maintain a single managed plan comment per issue, and transition state atomically. Use whenever the user asks to claim, scout, plan, build, sync, publish, or close agent-actionable GitHub issues."
+description: "`gh` mechanics for the `agent:todo` issue lifecycle defined in this repo's AGENTS.md: identify TODO issues via the `agent:todo` label, claim with mutually-exclusive status labels, maintain a single managed plan comment per issue, and transition state atomically. Use whenever the user asks to claim, scout, plan, build, sync, publish, or close agent-actionable GitHub issues or create a todo item on Github or a todo issue or create a new issue."
 ---
 
 # GitHub Issue Workflow

--- a/.cursor/skills/github-issue-workflow/SKILL.md
+++ b/.cursor/skills/github-issue-workflow/SKILL.md
@@ -1,0 +1,295 @@
+---
+name: github-issue-workflow
+description: "`gh` mechanics for the `agent:todo` issue lifecycle defined in this repo's AGENTS.md: identify TODO issues via the `agent:todo` label, claim with mutually-exclusive status labels, maintain a single managed plan comment per issue, and transition state atomically. Use whenever the user asks to claim, scout, plan, build, sync, publish, or close agent-actionable GitHub issues."
+---
+
+# GitHub Issue Workflow
+
+Implements the lifecycle defined in [`AGENTS.md`](../../AGENTS.md) using GitHub Issues + the `gh` CLI. **This file is the playbook (how); AGENTS.md is the rulebook (what and why).** If they disagree, AGENTS.md wins.
+
+## Operating guardrails
+
+- In the face of uncertainty, refuse the temptation to guess and ask the user.
+- Every agent-authored issue comment or reply must end with `🤖` as the final non-whitespace character.
+
+## Pre-flight: `gh`
+
+The user must have the `gh` CLI installed and authenticated.
+
+1. Installation (if missing) -> test with `which gh`, if not found, install with https://github.com/cli/cli#installation
+2. Authentication -> test with `gh auth status`, tell the user to run `gh auth login` if user isn't logged-in. 
+
+## Label vocabulary
+
+Two orthogonal axes.
+
+### Type label (persistent)
+
+| Label        | Meaning                                                                                                              |
+| ------------ | -------------------------------------------------------------------------------------------------------------------- |
+| `agent:todo` | Issue is agent-actionable. Required for the workflow to apply. Persists across the lifecycle, including after close. |
+
+Issues without `agent:todo` are out of scope (bugs, human discussions, feature requests).
+
+**Create agent TODOs** with the [Agent TODO](.github/ISSUE_TEMPLATE/agent-todo.yml) issue template (template chooser → *Agent TODO*). It applies `agent:todo` automatically and requires branch intent.
+
+### Status labels (mutually exclusive, one at a time)
+
+No status label means the issue is **unclaimed**.
+
+| Label             | Meaning                                                             |
+| ----------------- | ------------------------------------------------------------------- |
+| `agent:scouting`  | A scout is preparing the plan; read-only except the plan comment    |
+| `agent:building`  | A builder is implementing; one per session                          |
+| `agent:blocked`   | Paused awaiting user input or external dependency                   |
+| `agent:reviewing` | Implementation done, awaiting critique/feedback before commit       |
+| `agent:done`      | PR merged; post-merge issue finalization complete (or already closed) |
+
+### Bootstrap (one-time per repo)
+
+```bash
+gh label create "agent:todo"      --color 0e8a16 --description "Agent: TODO (agent-actionable)"
+gh label create "agent:scouting"  --color a2eeef --description "Agent status: scouting (plan in progress)"
+gh label create "agent:building"  --color fbca04 --description "Agent status: building (implementation in progress)"
+gh label create "agent:blocked"   --color d73a4a --description "Agent status: blocked (awaiting user or external)"
+gh label create "agent:reviewing" --color 0075ca --description "Agent status: reviewing (critique pending)"
+gh label create "agent:done"      --color cfd3d7 --description "Agent status: done (merged and closed)"
+```
+
+## Branch (required on every agent TODO)
+
+Every `agent:todo` issue must declare where work happens. Issues filed via the Agent TODO template include form fields **`Branch`** (`branch_mode`) and **`Existing branch name`** (`branch_name`). For issues created another way, the body must state the same information explicitly.
+
+| `branch_mode` | Meaning | Agent action |
+| ------------- | ------- | ------------ |
+| `new` | New work on a fresh branch | Derive branch name (below), create branch from default branch, work in a **worktree** |
+| `existing` | More work on a branch that already exists | Check out that branch (worktree if the user's setup uses them); **do not** create a new branch |
+
+### Pickup gate
+
+Before claiming, read the issue body (or `gh issue view <num> --json body`):
+
+1. If **`Branch`** is missing, **stop** — ask the user to add branch intent or re-file with the Agent TODO template.
+2. If **`Branch`** is `existing` and **`Existing branch name`** is empty, **stop** — ask the user to fill the branch name.
+3. If **`Branch`** is `existing`, verify the branch exists: `git ls-remote --heads origin <branch_name>` (or ask the user if offline).
+
+Record the resolved branch in the managed plan **Status** block (`Branch: …`).
+
+### New branch naming
+
+When `branch_mode` is `new`, derive the branch **before** substantive work:
+
+1. Start from the issue title: strip a leading `[agent todo]` (case-insensitive), lowercase, replace non-alphanumerics with `-`, collapse repeated hyphens, trim hyphens, truncate slug to **48** characters.
+2. Prefix by intent (default **`feat`**):
+   - `fix-` — bugfix / regression
+   - `docs-` — documentation only
+   - `chore-` — tooling, CI, repo hygiene
+   - `feat-` — everything else
+3. Final form: `<prefix>-<slug>` (e.g. `feat-add-agent-todo-template`). No slashes; match existing repo branches like `feat-agentic-research-workflow`.
+
+Post the chosen branch name in a short issue comment when first claiming (so humans see it before build):
+
+```bash
+gh issue comment <num> --body "Branch: \`feat-my-slug\` (new — worktree)
+
+🤖"
+```
+
+### Worktree for `new`
+
+When `branch_mode` is `new`, implement in a **separate worktree**, not the main checkout (AGENTS.md *Worktrees*):
+
+```bash
+# From repo root; adjust default branch if not main
+git fetch origin main
+SLUG="my-slug"   # from naming steps above, without prefix
+BRANCH="feat-${SLUG}"
+WT="../$(basename "$PWD")-${SLUG}"
+git worktree add -b "$BRANCH" "$WT" origin/main
+cd "$WT"
+```
+
+If the user does not use worktrees, or worktrees live elsewhere, **ask** before falling back to an in-place branch checkout.
+
+For `existing`, prefer a worktree on that branch when one already exists; otherwise `git worktree add <path> <branch_name>` or checkout per user preference.
+
+## Claim and state transitions
+
+Before claiming, inspect the issue:
+
+```bash
+gh issue view <num> --json number,title,labels,assignees,state,body
+```
+
+Run the **pickup gate** (branch fields) before setting a status label.
+
+If another agent's `agent:scouting` or `agent:building` is present, **stop and ask the user** (per AGENTS.md rule 3).
+
+Every status change is a single atomic `gh issue edit`:
+
+```bash
+gh issue edit <num> \
+  --add-label "agent:<new_status>" \
+  --remove-label "agent:scouting,agent:building,agent:blocked,agent:reviewing,agent:done"
+```
+
+`gh` silently ignores `--remove-label` entries that are not present, so the same remove-list is safe for every transition. **Never include `agent:todo` in the remove list** — the type label is preserved across the lifecycle.
+
+## Builder grill approval gate (before implementation)
+
+After a plan is approved and before code changes:
+
+1. Builder runs `/grill-with-docs` and updates the managed comment with:
+   - `Grill outcomes`
+   - `Open questions (async scout)` (if any remain)
+   - `Approval gate`
+   - `Build authorization`
+2. Transition issue to `agent:blocked` while waiting for explicit user build approval.
+3. Ask for explicit approval to proceed.
+4. Accept approval when the user provides an explicitly affirmative intent containing verb language rooted in `build` or `implement` (including standard inflections like `building`, `implemented`).
+5. Treat non-affirmative, speculative, or conditional wording as non-approval (for example: "maybe build", "we could implement later", "if tests pass then build").
+6. If approval is ambiguous, ask one direct confirmation question and do not infer intent.
+7. While waiting, send one concise reminder only; do not auto-proceed on timeout.
+8. Move to `agent:building` only after explicit approval.
+
+## Managed plan comment
+
+Exactly one agent-owned comment per issue, bracketed by stable markers:
+
+```markdown
+<!-- agent-plan:start -->
+
+## Plan
+
+<scouting or building plan>
+
+### Status
+
+- Phase: scouting | building | reviewing | done
+- Branch: <name> (`new` | `existing` per issue)
+- Last updated: <ISO date>
+- Commit: <hash> (when applicable)
+
+### Grill outcomes
+
+- Decisions confirmed:
+- Assumptions challenged:
+- Risks noted:
+
+### Open questions (async scout)
+
+- Question:
+  - Recommended answer:
+  - Risk if wrong:
+  - Needs user confirmation:
+
+### Approval gate
+
+- Builder grill completed: yes | no
+- Awaiting explicit build approval: yes | no
+
+### Build authorization
+
+- Approval phrase:
+- Approved by:
+- Approved at:
+
+<!-- agent-plan:end -->
+
+🤖
+```
+
+### Find an existing managed comment
+
+```bash
+gh issue view <num> --json comments \
+  --jq '.comments[] | select(.body | contains("<!-- agent-plan:start -->")) | {id, url}'
+```
+
+### Create the first time
+
+```bash
+gh issue comment <num> --body-file plan.md
+```
+
+### Edit in place
+
+`gh` has no `comment --edit`. Use the REST API:
+
+```bash
+gh api --method PATCH \
+  /repos/<owner>/<repo>/issues/comments/<comment_id> \
+  -f body="$(cat plan.md)"
+```
+
+If you cannot reliably find the prior managed comment, **stop and ask** — never post a duplicate plan comment.
+
+## Publication checkpoints
+
+The managed comment **must** be up to date at:
+
+1. End of scouting (plan ready for user review).
+2. Start of build (plan confirmed).
+3. End of build, before commit (critique + verification summary).
+4. After commit (final status + commit hash).
+5. After merge, before close (final status + merge commit hash).
+
+Keep checkpoint updates concise. At each checkpoint, update only fields that changed (phase, branch, timestamps, approvals, commit/merge hash, and short risks/findings deltas). Between checkpoints, prefer local drafts in `plans/scouting-<slug>.md` or `plans/building-<slug>.md` to limit `gh` traffic.
+
+For any non-managed issue comment (questions, status notes, branch announcements), append `🤖` as the final non-whitespace character.
+
+## Wrap-up integration (post-merge close-out)
+
+Keep `agent:building` during PR open, CI, and merge. After PR merge succeeds, run this close-out sequence:
+
+1. Resolve linked issue from the branch work item (`Refs #<num>` convention; avoid `Closes #<num>` automation).
+2. Update the managed comment one last time with `Phase: done` and `Commit: <merge_sha>`.
+3. Transition status labels to `agent:done` (removing other `agent:*` status labels).
+4. Close the issue as completed.
+
+```bash
+gh issue edit <num> \
+  --add-label "agent:done" \
+  --remove-label "agent:scouting,agent:building,agent:blocked,agent:reviewing"
+gh issue close <num> --reason completed
+```
+
+## Closing an issue
+
+Only close after merge has succeeded and the post-merge close-out sequence above is complete. The `agent:todo` label remains on the closed issue (useful for `gh issue list --state closed --label agent:todo`).
+
+## Conflict resolution
+
+GitHub state wins (AGENTS.md rule 6). Edge cases:
+
+| Conflict                                       | Resolution                                |
+| ---------------------------------------------- | ----------------------------------------- |
+| Two managed comments found on one issue        | Stop. Ask user which to keep.             |
+| Local `plans/built-*.md` but issue still open  | Sync post-merge: update issue with merge hash, set `agent:done`, close. |
+| Local `plans/scouted-*.md` but no issue exists | Ask whether to create the issue.          |
+
+## `gh` cheat sheet
+
+| Need                          | Command                                                                                               |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------- |
+| List open unclaimed           | `gh issue list --state open --label "agent:todo" --search "-label:agent:scouting -label:agent:building -label:agent:blocked -label:agent:reviewing"` |
+| Read branch fields            | `gh issue view <num> --json body --jq .body` (look for `### Branch` / `### Existing branch name`) |
+| Verify remote branch exists   | `git ls-remote --heads origin <branch_name>`                                                          |
+| List all agent-completed work | `gh issue list --state closed --label "agent:todo" --label "agent:done"`                              |
+| Show issue + all comments     | `gh issue view <num> --comments`                                                                      |
+| Atomic label transition       | `gh issue edit <num> --add-label "<a>" --remove-label "<b>,<c>"`                                      |
+| Create plan comment           | `gh issue comment <num> --body-file plan.md`                                                          |
+| Edit comment in place         | `gh api --method PATCH /repos/<o>/<r>/issues/comments/<id> -f body="$(cat plan.md)"`                  |
+| Post-merge close-out          | `gh issue edit <num> --add-label "agent:done" --remove-label "agent:scouting,agent:building,agent:blocked,agent:reviewing" && gh issue close <num> --reason completed` |
+| Close as completed            | `gh issue close <num> --reason completed`                                                             |
+| Check repo visibility         | `gh repo view --json visibility`                                                                      |
+
+## Security (gh-specific)
+
+AGENTS.md rule 7 forbids publishing secrets. Concrete gh-specific guardrails:
+
+- **Never paste** `gh auth token` output, `Authorization:` headers, `.env` contents, API keys, signed URLs, or session cookies into issue bodies or comments.
+- **Avoid absolute local paths** in comments; use repo-relative paths.
+- **Sanitize logs and tracebacks** before pasting — strip credentials, IPs, hostnames, customer/PII data.
+- **Check `gh repo view --json visibility`** before pasting implementation detail into a comment you would not put in a public README.
+- If you find pre-existing secrets in an issue or comment, **stop and warn the user** instead of silently editing.

--- a/.cursor/skills/github-issue-workflow/SKILL.md
+++ b/.cursor/skills/github-issue-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github-issue-workflow
-description: "`gh` mechanics for the `agent:todo` issue lifecycle defined in this repo's AGENTS.md: identify TODO issues via the `agent:todo` label, claim with mutually-exclusive status labels, maintain a single managed plan comment per issue, and transition state atomically. Use whenever the user asks to claim, scout, plan, build, sync, publish, or close agent-actionable GitHub issues."
+description: "`gh` mechanics for the `agent:todo` issue lifecycle defined in this repo's AGENTS.md: identify TODO issues via the `agent:todo` label, claim with mutually-exclusive status labels, maintain a single managed plan comment per issue, and transition state atomically. Use whenever the user asks to claim, scout, plan, build, sync, publish, or close agent-actionable GitHub issues or create a todo item on Github or a todo issue or create a new issue."
 ---
 
 # GitHub Issue Workflow

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -56,6 +56,10 @@ _Avoid_: template, plugin, config
 The collection of Agent Assets bundled inside the siesta package, used as the only install source.
 _Avoid_: registry, store, remote assets
 
+**Detected Agent Asset**:
+An Agent Asset already present on disk under a Provider directory for a given Asset Scope — the set `siesta agents remove` operates on.
+_Avoid_: available (that term is reserved for the Catalog on `add` commands)
+
 **Provider**:
 A target agent tool whose on-disk conventions siesta installs into — Cursor or Claude.
 _Avoid_: vendor, tool, platform, client
@@ -111,7 +115,7 @@ The rule that branch commits and PR context use `Refs #<num>` for linkage, while
 ## Relationships
 
 - An **Agent Asset Catalog** contains **Skills**, **Rules**, and **Constitutions**; it is the only install source (bundled, no network).
-- The **Quickstart Config** selects a subset of the **Agent Asset Catalog**; running `siesta agents quickstart` is equivalent to running the individual `add-*` commands for each listed asset.
+- The **Quickstart Config** selects a subset of the **Agent Asset Catalog**; running `siesta agents quickstart` is equivalent to running the individual `agents add` commands for each listed asset.
 - A **Constitution** is rendered as `AGENTS.md` (source of truth) plus, for the Claude **Provider**, a `CLAUDE.md` `@AGENTS.md` stub.
 - A **Rule** has exactly one canonical `.mdc` source and is **Provider Mirrored** to a translated Claude `.md`.
 - Every Agent Asset install resolves to a **Provider** × **Asset Scope** destination.
@@ -119,7 +123,7 @@ The rule that branch commits and PR context use `Refs #<num>` for linkage, while
 
 ## Example dialogue
 
-> **Dev:** "When I run `add-constitution --claude`, does it only write `CLAUDE.md`?"
+> **Dev:** "When I run `agents add constitution --claude`, does it only write `CLAUDE.md`?"
 > **Maintainer:** "No — a **Constitution**'s source of truth is `AGENTS.md`, so we always write it; `CLAUDE.md` is just the `@AGENTS.md` stub. `AGENTS.md` is there for Cursor compatibility, not because Claude needs it."
 > **Dev:** "And the **Rules**?"
 > **Maintainer:** "Each is authored once as `.mdc`. The Claude copy is **Provider Mirrored** — same intent, vendor-translated frontmatter."

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -38,6 +38,17 @@ A valid outcome where the user selects no actions and the command exits successf
 User interruption during prompt collection that exits with code 130 at the CLI entrypoint, before any Mutation.
 _Avoid_: abort, quit
 
+**Conflict**:
+An existing artifact on disk that a Mutation would overwrite or corrupt if run unconditionally.
+
+**Conflict Resolution**:
+The sub-process within the Prompt Collection Phase where each detected Conflict is surfaced to the user, who declares skip, overwrite, or abort. All Conflict Resolutions are collected before the first Mutation — guaranteeing that Abort leaves the project state identical to its pre-run state.
+_Avoid_: guard, check, validation (those are Validation Phase terms)
+
+**Abort**:
+A deliberate user choice during Conflict Resolution that exits before any Mutation, leaving project state identical to its pre-run state. Distinguished from Cancellation (which is an unintentional interrupt, exit code 130) and from error exits triggered by the CLI itself.
+_Avoid_: cancel, quit
+
 ### CLI structure
 
 **CLI Domain Module**:

--- a/docs/adr/0005-nested-agent-asset-operations.md
+++ b/docs/adr/0005-nested-agent-asset-operations.md
@@ -1,0 +1,37 @@
+---
+status: accepted
+---
+
+# Nested Agent Asset Operations
+
+The `siesta agents` command group now separates operations from Agent Asset kinds:
+`siesta agents add skill`, `add rule`, and `add constitution` install bundled assets;
+`siesta agents remove skill`, `remove rule`, and `remove constitution` remove
+detected local or global assets. The previous flat commands (`add-skill`, `add-rule`,
+`add-constitution`) were removed without compatibility aliases.
+
+## Considered Options
+
+- Keep flat `add-*` commands and add parallel `remove-*` commands — rejected: the
+  grammar duplicates the operation in every command name and does not scale if more
+  operations are added later.
+- Add nested commands while keeping deprecated flat aliases — rejected: the CLI is
+  still early enough to prefer a clean public surface over compatibility shims.
+- Allow non-interactive removal sweeps over detected assets — rejected: removal is
+  destructive; every candidate must be confirmed individually before mutation.
+
+## Decision
+
+- Nest Agent Asset kinds under `add` and `remove` subcommands.
+- Break the old flat command names intentionally.
+- Gate every removal candidate with an explicit questionary confirmation; `--force`
+  on Constitution removal permits user-authored content but never bypasses confirmation.
+- Default removal scope to local, matching add defaults.
+
+## Consequences
+
+- Scripts and docs must use the nested command paths.
+- Removal is safer but always requires interactive confirmation (or explicit names
+  plus per-path confirmation).
+- `quickstart` remains a top-level `agents` command because it installs the
+  Quickstart Config subset, not a single Agent Asset kind.

--- a/docs/adr/0006-conflict-resolution-in-prompt-collection-phase.md
+++ b/docs/adr/0006-conflict-resolution-in-prompt-collection-phase.md
@@ -1,0 +1,18 @@
+---
+status: accepted
+---
+
+# Conflict Resolution belongs in the Prompt Collection Phase
+
+When `siesta project quickstart` detects that an artifact it would write already exists on disk (a Conflict), the resolution decision — skip, overwrite, or abort — is collected during the Prompt Collection Phase, before the first Mutation. This preserves the Ordering Contract: if the user chooses Abort, the project state is identical to its pre-run state, with nothing to roll back.
+
+## Considered Options
+
+- **Resolve conflicts mid-execution** — prompt the user at the point of each Mutation, with a "retry after manual fix" option. Rejected: Abort mid-execution would require rolling back already-completed Mutations (filesystem writes, `uv add` side effects, pre-commit installs), which is not feasible. The retry option also creates a mid-execution interactive pause that breaks scripted use.
+- **Always abort on conflict in non-interactive mode** — skip the prompt, treat any Conflict as a hard failure unless `--overwrite` is explicit. Rejected: too blunt; `--no-X` flags already let users opt out of individual steps.
+
+## Consequences
+
+- The Prompt Collection Phase pre-scans all artifact paths before executing anything.
+- The "retry after manual fix" pattern is replaced by: choose Abort (clean exit), fix manually, re-run.
+- In non-TTY environments, any unresolved Conflict (`overwrite` not explicitly set) aborts before any Mutation.

--- a/src/siesta/cli/agents_app.py
+++ b/src/siesta/cli/agents_app.py
@@ -2,6 +2,7 @@
 """Agent asset CLI commands (``siesta agents``)."""
 
 import sys
+from collections.abc import Callable
 from pathlib import Path
 from textwrap import dedent
 from typing import Annotated
@@ -562,11 +563,16 @@ def remove_constitution_cmd(
     confirmed_agents = False
     confirmed_claude = False
 
-    if agents_path and agents_path.exists():
+    agents_exists = bool(agents_path and agents_path.exists())
+    claude_exists = bool(claude_path and claude_path.exists())
+    if agents_exists or claude_exists:
+        _require_tty()
+
+    if agents_exists:
         label = f"AGENTS.md ({_display_path(agents_path)})"
         confirmed_agents = logger.confirm(f"Remove {label}?")
 
-    if claude_path and claude_path.exists():
+    if claude_exists:
         label = f"CLAUDE.md ({_display_path(claude_path)})"
         confirmed_claude = logger.confirm(f"Remove {label}?")
 
@@ -586,19 +592,39 @@ def remove_constitution_cmd(
     print_removal_summary(summary)
 
 
+def _require_tty() -> None:
+    """Abort cleanly when per-file removal confirmations cannot be collected.
+
+    Removal always confirms each target individually, which needs a terminal.
+    In a non-TTY environment, abort with guidance instead of letting the
+    confirmation prompt raise a bare ``KeyboardInterrupt``.
+    """
+    if not sys.stdin.isatty():
+        logger.abort(
+            "Confirming removals requires a terminal (no TTY). "
+            "Re-run in an interactive shell."
+        )
+
+
 def _build_removal_candidates(
     names: list[str],
     providers: list[str],
     scope: str,
-    target_fn,
+    target_fn: Callable[[str, str, str], Path],
     kind: str,
 ) -> list[tuple[str, Path, str, str]]:
-    """Build ``(label, path, name, provider)`` tuples for existing targets."""
+    """Build ``(label, path, name, provider)`` tuples for existing targets.
+
+    Targets are de-duplicated by path so a repeated name (``remove skill x x``)
+    is only proposed — and confirmed — once.
+    """
     candidates: list[tuple[str, Path, str, str]] = []
+    seen: set[Path] = set()
     for name in names:
         for provider in providers:
             dest = target_fn(provider, scope, name)
-            if dest.exists():
+            if dest.exists() and dest not in seen:
+                seen.add(dest)
                 label = f"{provider} {kind} {name!r} ({_display_path(dest)})"
                 candidates.append((label, dest, name, provider))
     return candidates
@@ -608,6 +634,8 @@ def _confirm_removal_candidates(
     candidates: list[tuple[str, Path, str, str]],
 ) -> tuple[list[tuple[str, Path, str, str]], list[str]]:
     """Confirm each candidate; return confirmed tuples and skipped labels."""
+    if candidates:
+        _require_tty()
     path_candidates = [(label, path) for label, path, _, _ in candidates]
     confirmed_paths, skipped_labels = collect_confirmed_removals(path_candidates)
     confirmed = [

--- a/src/siesta/cli/agents_app.py
+++ b/src/siesta/cli/agents_app.py
@@ -378,7 +378,12 @@ def remove_skill_cmd(
     providers = resolve_providers(cursor, claude, both)
     detected = detect_installed_skills(providers, scope)
     selected = resolve_remove_selection(
-        list(names), detected, interactive, kind="skill", providers=providers, scope=scope
+        list(names),
+        detected,
+        interactive,
+        kind="skill",
+        providers=providers,
+        scope=scope,
     )
     if not selected:
         if detected:
@@ -458,7 +463,12 @@ def remove_rule_cmd(
     providers = resolve_providers(cursor, claude, both)
     detected = detect_installed_rules(providers, scope)
     selected = resolve_remove_selection(
-        list(names), detected, interactive, kind="rule", providers=providers, scope=scope
+        list(names),
+        detected,
+        interactive,
+        kind="rule",
+        providers=providers,
+        scope=scope,
     )
     if not selected:
         if detected:

--- a/src/siesta/cli/agents_app.py
+++ b/src/siesta/cli/agents_app.py
@@ -2,6 +2,7 @@
 """Agent asset CLI commands (``siesta agents``)."""
 
 import sys
+from pathlib import Path
 from textwrap import dedent
 from typing import Annotated
 
@@ -9,17 +10,29 @@ from cyclopts import App, Parameter
 
 from siesta.utils.agents import (
     DEFAULT_CONSTITUTION,
+    _display_path,
     available_constitutions,
     available_rules,
     available_skills,
+    collect_confirmed_removals,
+    constitution_paths,
+    detect_installed_rules,
+    detect_installed_skills,
     install_constitution,
     install_quickstart,
     install_rule,
     install_skill,
+    print_removal_summary,
     print_summary,
+    remove_constitution,
+    remove_rule,
+    remove_skill,
     resolve_providers,
+    resolve_remove_selection,
     resolve_scope,
     resolve_selection,
+    rule_target,
+    skill_target,
 )
 from siesta.utils.common import logger
 
@@ -27,8 +40,8 @@ agents_app = App(
     name="agents",
     help=dedent(
         """
-        Install agent assets (Skills, Rules, Constitution) into a repository or
-        user home, for Cursor and/or Claude.
+        Install and remove agent assets (Skills, Rules, Constitution) in a
+        repository or user home, for Cursor and/or Claude.
 
         Upgrade with ``$ siesta self update``.
         """.strip()
@@ -36,13 +49,32 @@ agents_app = App(
 )
 """:py:class:`cyclopts.App`: The app for the ``siesta agents`` sub-command."""
 
+add_app = App(
+    name="add",
+    help="Install bundled Agent Assets (Skills, Rules, or Constitution).",
+)
+remove_app = App(
+    name="remove",
+    help="Remove detected Agent Assets (Skills, Rules, or Constitution).",
+)
+agents_app.command(add_app)
+agents_app.command(remove_app)
+
+
+def _merge_summaries(
+    combined: dict[str, list[str]], result: dict[str, list[str]]
+) -> None:
+    """Merge one install summary into *combined*."""
+    for key in combined:
+        combined[key].extend(result.get(key, []))
+
 
 # ---------------------------------------------------------------------------
-# add-skill
+# add skill / rule / constitution
 # ---------------------------------------------------------------------------
 
 
-@agents_app.command(name="add-skill")
+@add_app.command(name="skill")
 def add_skill(
     names: list[str] = [],
     *,
@@ -59,7 +91,7 @@ def add_skill(
     """Install one or more bundled Skills into the repository or user home.
 
     Without arguments, an interactive checklist is shown. Pass skill names
-    directly to skip the prompt (``siesta agents add-skill grill-with-docs``),
+    directly to skip the prompt (``siesta agents add skill grill-with-docs``),
     or use ``--all`` to install every available Skill.
 
     Examples
@@ -67,13 +99,13 @@ def add_skill(
     .. code-block:: bash
 
         # Interactive selection
-        $ siesta agents add-skill -i
+        $ siesta agents add skill -i
 
         # Install a specific skill for Cursor only
-        $ siesta agents add-skill grill-with-docs --cursor --local
+        $ siesta agents add skill grill-with-docs --cursor --local
 
         # Install all skills globally for Claude
-        $ siesta agents add-skill --all --claude --global
+        $ siesta agents add skill --all --claude --global
 
     Parameters
     ----------
@@ -104,7 +136,7 @@ def add_skill(
 
     available = available_skills()
     selected = resolve_selection(
-        list(names), all_, available, interactive, kind="skill"
+        list(names), all_, available, interactive, kind="skill", scope=scope
     )
     if not selected:
         logger.info("No skills selected; nothing to do.")
@@ -121,18 +153,12 @@ def add_skill(
             backup=backup,
             interactive=interactive,
         )
-        for key in combined:
-            combined[key].extend(result.get(key, []))
+        _merge_summaries(combined, result)
 
     print_summary(combined)
 
 
-# ---------------------------------------------------------------------------
-# add-rule
-# ---------------------------------------------------------------------------
-
-
-@agents_app.command(name="add-rule")
+@add_app.command(name="rule")
 def add_rule(
     names: list[str] = [],
     *,
@@ -157,13 +183,13 @@ def add_rule(
     .. code-block:: bash
 
         # Interactive selection
-        $ siesta agents add-rule -i
+        $ siesta agents add rule -i
 
         # Install a specific rule for both providers
-        $ siesta agents add-rule python-docstrings --both --local
+        $ siesta agents add rule python-docstrings --both --local
 
         # Install all rules globally
-        $ siesta agents add-rule --all --global
+        $ siesta agents add rule --all --global
 
     Parameters
     ----------
@@ -193,7 +219,9 @@ def add_rule(
     providers = resolve_providers(cursor, claude, both)
 
     available = available_rules()
-    selected = resolve_selection(list(names), all_, available, interactive, kind="rule")
+    selected = resolve_selection(
+        list(names), all_, available, interactive, kind="rule", scope=scope
+    )
     if not selected:
         logger.info("No rules selected; nothing to do.")
         sys.exit(0)
@@ -209,18 +237,12 @@ def add_rule(
             backup=backup,
             interactive=interactive,
         )
-        for key in combined:
-            combined[key].extend(result.get(key, []))
+        _merge_summaries(combined, result)
 
     print_summary(combined)
 
 
-# ---------------------------------------------------------------------------
-# add-constitution
-# ---------------------------------------------------------------------------
-
-
-@agents_app.command(name="add-constitution")
+@add_app.command(name="constitution")
 def add_constitution(
     name: str = DEFAULT_CONSTITUTION,
     *,
@@ -246,13 +268,13 @@ def add_constitution(
     .. code-block:: bash
 
         # Install the default constitution for both providers (local)
-        $ siesta agents add-constitution
+        $ siesta agents add constitution
 
         # Install into the user home for Claude only
-        $ siesta agents add-constitution --claude --global
+        $ siesta agents add constitution --claude --global
 
         # List available constitutions
-        $ siesta agents add-constitution --help
+        $ siesta agents add constitution --help
 
     Parameters
     ----------
@@ -298,6 +320,313 @@ def add_constitution(
 
 
 # ---------------------------------------------------------------------------
+# remove skill / rule / constitution
+# ---------------------------------------------------------------------------
+
+
+@remove_app.command(name="skill")
+def remove_skill_cmd(
+    names: list[str] = [],
+    *,
+    cursor: bool = False,
+    claude: bool = False,
+    both: bool = False,
+    local: bool = False,
+    global_: Annotated[bool, Parameter(name=["--global"])] = False,
+    backup: bool = False,
+    interactive: Annotated[bool, Parameter(name=["-i", "--interactive"])] = False,
+) -> None:
+    """Remove detected Skills from the repository or user home.
+
+    Without arguments, an interactive checklist of detected Skills is shown.
+    Pass skill names directly to skip the prompt
+    (``siesta agents remove skill grill-with-docs``).
+
+    Each proposed removal path is confirmed individually before any file is
+    deleted.
+
+    Examples
+    --------
+    .. code-block:: bash
+
+        # Interactive selection
+        $ siesta agents remove skill -i
+
+        $ siesta agents remove skill grill-with-docs --cursor
+
+    Parameters
+    ----------
+    names : list[str], optional
+        Skill names to remove.
+    cursor : bool, optional
+        Target the Cursor provider.
+    claude : bool, optional
+        Target the Claude provider.
+    both : bool, optional
+        Target both providers (default when no provider flag is given).
+    local : bool, optional
+        Remove from the current repository (default).
+    global_ : bool, optional
+        Remove from the user home.
+    backup : bool, optional
+        Back up targets before removing.
+    interactive : bool, optional
+        Enable interactive prompts (``-i``).
+    """
+    # --- Validation phase ---
+    scope = resolve_scope(local, global_)
+    providers = resolve_providers(cursor, claude, both)
+    detected = detect_installed_skills(providers, scope)
+    selected = resolve_remove_selection(
+        list(names), detected, interactive, kind="skill", providers=providers, scope=scope
+    )
+    if not selected:
+        if detected:
+            logger.info("No skills selected; nothing to do.")
+        sys.exit(0)
+
+    candidates = _build_removal_candidates(
+        selected, providers, scope, skill_target, "skill"
+    )
+
+    # --- Prompt collection phase ---
+    confirmed, skipped = _confirm_removal_candidates(candidates)
+
+    # --- Execution phase ---
+    combined: dict[str, list[str]] = {"removed": [], "skipped": [], "backed_up": []}
+    combined["skipped"].extend(skipped)
+
+    confirmed_by_name = _group_confirmed_providers(confirmed)
+    for skill_name, confirmed_providers in confirmed_by_name.items():
+        result = remove_skill(skill_name, confirmed_providers, scope, backup=backup)
+        _merge_removal_summaries(combined, result)
+
+    print_removal_summary(combined)
+
+
+@remove_app.command(name="rule")
+def remove_rule_cmd(
+    names: list[str] = [],
+    *,
+    cursor: bool = False,
+    claude: bool = False,
+    both: bool = False,
+    local: bool = False,
+    global_: Annotated[bool, Parameter(name=["--global"])] = False,
+    backup: bool = False,
+    interactive: Annotated[bool, Parameter(name=["-i", "--interactive"])] = False,
+) -> None:
+    """Remove detected Rules from the repository or user home.
+
+    Without arguments, an interactive checklist of detected Rules is shown.
+    Pass rule names directly to skip the prompt
+    (``siesta agents remove rule python-docstrings``).
+
+    Each proposed removal path is confirmed individually before any file is
+    deleted.
+
+    Examples
+    --------
+    .. code-block:: bash
+
+        # Interactive selection
+        $ siesta agents remove rule -i
+
+        $ siesta agents remove rule python-docstrings --claude
+
+    Parameters
+    ----------
+    names : list[str], optional
+        Rule names to remove (without extension).
+    cursor : bool, optional
+        Target the Cursor provider.
+    claude : bool, optional
+        Target the Claude provider.
+    both : bool, optional
+        Target both providers (default when no provider flag is given).
+    local : bool, optional
+        Remove from the current repository (default).
+    global_ : bool, optional
+        Remove from the user home.
+    backup : bool, optional
+        Back up targets before removing.
+    interactive : bool, optional
+        Enable interactive prompts (``-i``).
+    """
+    # --- Validation phase ---
+    scope = resolve_scope(local, global_)
+    providers = resolve_providers(cursor, claude, both)
+    detected = detect_installed_rules(providers, scope)
+    selected = resolve_remove_selection(
+        list(names), detected, interactive, kind="rule", providers=providers, scope=scope
+    )
+    if not selected:
+        if detected:
+            logger.info("No rules selected; nothing to do.")
+        sys.exit(0)
+
+    candidates = _build_removal_candidates(
+        selected, providers, scope, rule_target, "rule"
+    )
+
+    # --- Prompt collection phase ---
+    confirmed, skipped = _confirm_removal_candidates(candidates)
+
+    # --- Execution phase ---
+    combined: dict[str, list[str]] = {"removed": [], "skipped": [], "backed_up": []}
+    combined["skipped"].extend(skipped)
+
+    confirmed_by_name = _group_confirmed_providers(confirmed)
+    for rule_name, confirmed_providers in confirmed_by_name.items():
+        result = remove_rule(rule_name, confirmed_providers, scope, backup=backup)
+        _merge_removal_summaries(combined, result)
+
+    print_removal_summary(combined)
+
+
+@remove_app.command(name="constitution")
+def remove_constitution_cmd(
+    name: str = "",
+    *,
+    cursor: bool = False,
+    claude: bool = False,
+    both: bool = False,
+    local: bool = False,
+    global_: Annotated[bool, Parameter(name=["--global"])] = False,
+    force: bool = False,
+    backup: bool = False,
+    interactive: Annotated[bool, Parameter(name=["-i", "--interactive"])] = False,
+) -> None:
+    """Remove detected Constitution files (AGENTS.md / CLAUDE.md).
+
+    Each file is confirmed individually. ``AGENTS.md`` is removed only when it
+    matches a bundled Constitution source unless ``--force`` is passed.
+    ``CLAUDE.md`` import stubs may be deleted; mixed content keeps the body and
+    drops only the ``@AGENTS.md`` import line.
+
+    Examples
+    --------
+    .. code-block:: bash
+
+        $ siesta agents remove constitution
+
+        $ siesta agents remove constitution --claude --force
+
+    Parameters
+    ----------
+    name : str, optional
+        Unused catalog name placeholder kept for symmetry with ``add constitution``.
+    cursor : bool, optional
+        Target the Cursor provider.
+    claude : bool, optional
+        Target the Claude provider.
+    both : bool, optional
+        Target both providers (default when no provider flag is given).
+    local : bool, optional
+        Remove from the current repository (default).
+    global_ : bool, optional
+        Remove from the user home.
+    force : bool, optional
+        Allow removing user-authored Constitution files after confirmation.
+    backup : bool, optional
+        Back up targets before removing or rewriting.
+    interactive : bool, optional
+        Reserved for future selection flows; confirmations are always required.
+    """
+    del name, interactive  # constitution removal always confirms each file explicitly
+
+    # --- Validation phase ---
+    scope = resolve_scope(local, global_)
+    providers = resolve_providers(cursor, claude, both)
+    agents_path, claude_path = constitution_paths(providers, scope)
+
+    if providers == ["cursor"] and scope == "global":
+        logger.warning(
+            "Constitution is project-scoped for Cursor; nothing to do globally. "
+            "Tip: use --local (default) or --claude to target Claude's global ~/.claude/."
+        )
+        print_removal_summary({"removed": [], "skipped": [], "backed_up": []})
+        return
+
+    # --- Prompt collection phase ---
+    confirmed_agents = False
+    confirmed_claude = False
+
+    if agents_path and agents_path.exists():
+        label = f"AGENTS.md ({_display_path(agents_path)})"
+        confirmed_agents = logger.confirm(f"Remove {label}?")
+
+    if claude_path and claude_path.exists():
+        label = f"CLAUDE.md ({_display_path(claude_path)})"
+        confirmed_claude = logger.confirm(f"Remove {label}?")
+
+    if not confirmed_agents and not confirmed_claude:
+        logger.info("No constitution files confirmed; nothing to do.")
+        sys.exit(0)
+
+    # --- Execution phase ---
+    summary = remove_constitution(
+        providers,
+        scope,
+        force=force,
+        backup=backup,
+        confirmed_agents=confirmed_agents,
+        confirmed_claude=confirmed_claude,
+    )
+    print_removal_summary(summary)
+
+
+def _build_removal_candidates(
+    names: list[str],
+    providers: list[str],
+    scope: str,
+    target_fn,
+    kind: str,
+) -> list[tuple[str, Path, str, str]]:
+    """Build ``(label, path, name, provider)`` tuples for existing targets."""
+    candidates: list[tuple[str, Path, str, str]] = []
+    for name in names:
+        for provider in providers:
+            dest = target_fn(provider, scope, name)
+            if dest.exists():
+                label = f"{provider} {kind} {name!r} ({_display_path(dest)})"
+                candidates.append((label, dest, name, provider))
+    return candidates
+
+
+def _confirm_removal_candidates(
+    candidates: list[tuple[str, Path, str, str]],
+) -> tuple[list[tuple[str, Path, str, str]], list[str]]:
+    """Confirm each candidate; return confirmed tuples and skipped labels."""
+    path_candidates = [(label, path) for label, path, _, _ in candidates]
+    confirmed_paths, skipped_labels = collect_confirmed_removals(path_candidates)
+    confirmed = [
+        (label, path, name, provider)
+        for label, path, name, provider in candidates
+        if path in confirmed_paths
+    ]
+    return confirmed, skipped_labels
+
+
+def _group_confirmed_providers(
+    confirmed: list[tuple[str, Path, str, str]],
+) -> dict[str, list[str]]:
+    """Group confirmed removals by asset name and provider list."""
+    grouped: dict[str, list[str]] = {}
+    for _, _, name, provider in confirmed:
+        grouped.setdefault(name, []).append(provider)
+    return grouped
+
+
+def _merge_removal_summaries(
+    combined: dict[str, list[str]], result: dict[str, list[str]]
+) -> None:
+    """Merge one removal summary into *combined*."""
+    for key in combined:
+        combined[key].extend(result.get(key, []))
+
+
+# ---------------------------------------------------------------------------
 # quickstart
 # ---------------------------------------------------------------------------
 
@@ -317,8 +646,8 @@ def quickstart(
     """Install the curated default Agent Assets in one step.
 
     Reads the bundled Quickstart Config and installs the declared Skills,
-    Rules, and Constitution.  Equivalent to running ``add-skill``,
-    ``add-rule``, and ``add-constitution`` for each listed asset.
+    Rules, and Constitution.  Equivalent to running ``add skill``,
+    ``add rule``, and ``add constitution`` for each listed asset.
 
     Defaults to ``--local`` and both Providers when no flags are given.
 

--- a/src/siesta/cli/project_app.py
+++ b/src/siesta/cli/project_app.py
@@ -90,7 +90,9 @@ def _resolve_conflict(
     """
     if overwrite is True:
         if not allow_overwrite:
-            logger.warning(f"{name} already exists. Overwrite not supported for this step — skipping.")
+            logger.warning(
+                f"{name} already exists. Overwrite not supported for this step — skipping."
+            )
             return False
         return True
     if overwrite is False:

--- a/src/siesta/cli/project_app.py
+++ b/src/siesta/cli/project_app.py
@@ -1,6 +1,7 @@
 # Copyright 2025 Entalpic
 """Project CLI commands."""
 
+import sys
 from pathlib import Path
 from shutil import get_terminal_size
 from textwrap import dedent
@@ -61,6 +62,61 @@ def _confirm_quickstart_decision(message: str, default_key: str) -> bool:
     return logger.confirm(message, default=CLI_DEFAULTS[default_key])
 
 
+def _resolve_conflict(
+    name: str,
+    overwrite: bool | None,
+    allow_overwrite: bool = True,
+) -> bool:
+    """Resolve a Conflict between a planned Mutation and an existing artifact.
+
+    Must be called during the Prompt Collection Phase, before any Mutation.
+
+    Parameters
+    ----------
+    name : str
+        Human-readable description of the conflicting artifact (shown in prompts).
+    overwrite : bool | None
+        The global ``--overwrite`` flag. ``True`` = proceed, ``False`` = skip,
+        ``None`` = resolve at runtime.
+    allow_overwrite : bool, optional
+        Whether "overwrite" is a valid choice for this step. ``False`` for steps
+        where overwriting is not supported (e.g. ``uv init``).
+
+    Returns
+    -------
+    bool
+        ``True`` = proceed with the Mutation (overwrite). ``False`` = skip this step.
+        Never returns when the user chooses Abort — calls ``logger.abort()`` instead.
+    """
+    if overwrite is True:
+        if not allow_overwrite:
+            logger.warning(f"{name} already exists. Overwrite not supported for this step — skipping.")
+            return False
+        return True
+    if overwrite is False:
+        logger.warning(f"{name} already exists. Skipping.")
+        return False
+    # overwrite is None: resolve at runtime
+    if not sys.stdin.isatty():
+        logger.abort(
+            f"{name} already exists. "
+            "Pass --overwrite to overwrite or the matching --no-<feature> flag to skip."
+        )
+    if allow_overwrite:
+        choice = logger.select(
+            f"{name} already exists — what do you want to do?",
+            ["Skip (keep existing)", "Overwrite", "Abort"],
+        )
+    else:
+        choice = logger.select(
+            f"{name} already exists — what do you want to do?",
+            ["Skip (keep existing)", "Abort"],
+        )
+    if choice == "Abort":
+        logger.abort("Aborted.")
+    return choice == "Overwrite"
+
+
 @project_app.command(name="quickstart")
 def quickstart_project(
     as_app: bool = False,
@@ -70,7 +126,7 @@ def quickstart_project(
     deps: bool | None = None,
     docs_path: str = "./docs",
     as_main_deps: bool | None = None,
-    overwrite: bool = False,
+    overwrite: bool | None = None,
     interactive: Annotated[bool, Parameter(name=["-i", "--interactive"])] = False,
     branch: str = "main",
     contents: str = "src/siesta/boilerplate",
@@ -142,9 +198,9 @@ def quickstart_project(
     as_main_deps : bool, optional
         Whether to include docs dependencies in the main dependencies, by default
         ``None`` (i.e. prompt the user).
-    overwrite : bool, optional
-        Whether to overwrite existing files (if any). Will be passed to ``siesta
-        docs init``.
+    overwrite : bool | None, optional
+        How to handle existing artifacts. ``True`` = overwrite all, ``False`` = skip all,
+        ``None`` (default) = prompt in TTY or abort in non-TTY.
     interactive : bool, optional
         Enable interactive mode with prompts for all options (``-i``). By default,
         sensible defaults are used. User-specified flags always take precedence.
@@ -229,6 +285,21 @@ def quickstart_project(
         ipdb = _confirm_quickstart_decision(
             "Would you like to add ipdb as debugger?", "ipdb"
         )
+    ipdb_overwrite = False
+    if ipdb:
+        _inits = list(Path("src/").glob("**/__init__.py"))
+        if _inits:
+            _first_init = sorted(
+                [(_i, len(str(_i).split("/"))) for _i in _inits], key=lambda x: x[1]
+            )[0][0]
+            if "PYTHONBREAKPOINT" in _first_init.read_text():
+                result = _resolve_conflict(
+                    "ipdb debugger (PYTHONBREAKPOINT already present)", overwrite
+                )
+                if not result:
+                    ipdb = False
+                else:
+                    ipdb_overwrite = True
 
     if tests is None:
         tests = _confirm_quickstart_decision(
@@ -244,6 +315,13 @@ def quickstart_project(
         gitignore = _confirm_quickstart_decision(
             "Would you like to initialize the ``.gitignore`` file?", "gitignore"
         )
+    gitignore_overwrite = False
+    if gitignore and Path(".gitignore").exists():
+        result = _resolve_conflict(".gitignore", overwrite)
+        if not result:
+            gitignore = False
+        else:
+            gitignore_overwrite = True
 
     if docs is None:
         docs = _confirm_quickstart_decision(
@@ -252,6 +330,14 @@ def quickstart_project(
 
     if docs and interactive and docs_path == "./docs":
         docs_path = logger.prompt("Documentation path", default=docs_path)
+
+    docs_overwrite = False
+    if docs and resolve_path(docs_path).exists():
+        result = _resolve_conflict(f"docs at {resolve_path(docs_path)}", overwrite)
+        if not result:
+            docs = False
+        else:
+            docs_overwrite = True
 
     if agents is None:
         agents = _confirm_quickstart_decision(
@@ -274,9 +360,19 @@ def quickstart_project(
             else:
                 docs_with_uv = True
 
+    # Conflict Resolution: uv init. Not tied to a feature flag so resolved here,
+    # just before execution. Overwriting uv init is not supported by uv itself.
+    run_uv_init = not (Path("uv.lock").exists() or Path("pyproject.toml").exists())
+    if not run_uv_init:
+        _resolve_conflict(
+            "uv project (pyproject.toml or uv.lock already exists — safe to skip if already set up with uv)",
+            overwrite,
+            allow_overwrite=False,
+        )
+        logger.info("Skipping uv init — project already initialized.")
+
     # Execution phase: perform mutations after all decisions are collected.
-    has_uv_lock = Path("uv.lock").exists()
-    if not has_uv_lock:
+    if run_uv_init:
         cmd = ["uv", "init"]
         cmd.append(f"--name={project_name}")
         if as_app:
@@ -293,8 +389,6 @@ def quickstart_project(
         if initialized is False:
             logger.abort("Failed to initialize the project.")
         logger.info("Project initialized with uv.")
-    else:
-        logger.info("Project already initialized with uv.")
 
     if deps:
         dev_deps = load_deps()["dev"]
@@ -311,7 +405,7 @@ def quickstart_project(
         logger.info("Pre-commit hooks installed.")
 
     if ipdb:
-        add_ipdb_as_debugger()
+        add_ipdb_as_debugger(overwrite=ipdb_overwrite)
         logger.info("[r]ipdb[/r] added as debugger.")
 
     if tests:
@@ -334,7 +428,7 @@ def quickstart_project(
         logger.info("Test actions config written.")
 
     if gitignore:
-        write_gitignore()
+        write_gitignore(overwrite=gitignore_overwrite)
         logger.info("Gitignore written.")
 
     if docs:
@@ -343,7 +437,7 @@ def quickstart_project(
         init_docs(
             path=docs_path,
             as_main_deps=bool(as_main_deps),
-            overwrite=overwrite,
+            overwrite=docs_overwrite,
             deps=deps,
             uv=docs_with_uv,
             interactive=False,
@@ -356,8 +450,9 @@ def quickstart_project(
     if agents:
         # Back up existing agent files when overwriting so a user-authored
         # CLAUDE.md/AGENTS.md is recoverable from a .bak.
+        _overwrite = overwrite is True
         summary = install_quickstart(
-            ["cursor", "claude"], "local", force=overwrite, backup=overwrite
+            ["cursor", "claude"], "local", force=_overwrite, backup=_overwrite
         )
         print_summary(summary)
         logger.info("Agent assets installed.")

--- a/src/siesta/cli/project_app.py
+++ b/src/siesta/cli/project_app.py
@@ -123,6 +123,7 @@ def _resolve_conflict(
 def quickstart_project(
     as_app: bool = False,
     as_pkg: bool = False,
+    uv_init: bool | None = None,
     precommit: bool | None = None,
     docs: bool | None = None,
     deps: bool | None = None,
@@ -189,6 +190,11 @@ def quickstart_project(
         Whether to initialize the project as an app (just a script file to start with).
     as_pkg : bool, optional
         Whether to initialize the project as a package (with a package structure in the root directory).
+    uv_init : bool, optional
+        Whether to initialize a ``uv`` project (``$ uv init``), by default ``None`` (i.e.
+        prompt the user). Use ``--no-uv-init`` to skip — note the other steps (``--deps``,
+        ``--precommit``) need a ``uv`` project to exist, so skipping it on a fresh directory
+        will make them fail.
     precommit : bool, optional
         Whether to install pre-commit hooks, by default ``None`` (i.e. prompt the user).
     docs : bool, optional
@@ -241,6 +247,8 @@ def quickstart_project(
 
     # Setting defaults: only fill in values that weren't explicitly provided
     if not interactive:
+        if uv_init is None:
+            uv_init = CLI_DEFAULTS["uv_init"]
         if precommit is None:
             precommit = CLI_DEFAULTS["precommit"]
         if docs is None:
@@ -272,6 +280,11 @@ def quickstart_project(
         )
         as_app = layout == "Application script"
         as_pkg = layout == "Package without src/ layout"
+
+    if uv_init is None:
+        uv_init = _confirm_quickstart_decision(
+            "Would you like to initialize a uv project?", "uv_init"
+        )
 
     if deps is None:
         deps = _confirm_quickstart_decision(
@@ -335,7 +348,7 @@ def quickstart_project(
 
     docs_overwrite = False
     if docs and resolve_path(docs_path).exists():
-        result = _resolve_conflict(f"docs at {resolve_path(docs_path)}", overwrite)
+        result = _resolve_conflict(f"docs at {docs_path}", overwrite)
         if not result:
             docs = False
         else:
@@ -362,16 +375,28 @@ def quickstart_project(
             else:
                 docs_with_uv = True
 
-    # Conflict Resolution: uv init. Not tied to a feature flag so resolved here,
-    # just before execution. Overwriting uv init is not supported by uv itself.
-    run_uv_init = not (Path("uv.lock").exists() or Path("pyproject.toml").exists())
-    if not run_uv_init:
+    # Conflict Resolution: uv init. Overwriting uv init is not supported by uv
+    # itself, so this conflict is skip-only and resolved here, just before execution.
+    already_initialized = Path("uv.lock").exists() or Path("pyproject.toml").exists()
+    if uv_init is False:
+        # Explicit opt-out. Warn when there is no uv project yet, since the remaining
+        # steps (deps, pre-commit, ...) need one to exist.
+        if not already_initialized:
+            logger.warning(
+                "Skipping uv init on a fresh directory — dependency and pre-commit "
+                "steps may fail without a uv project."
+            )
+        run_uv_init = False
+    elif already_initialized:
+        run_uv_init = False
         _resolve_conflict(
             "uv project (pyproject.toml or uv.lock already exists — safe to skip if already set up with uv)",
             overwrite,
             allow_overwrite=False,
         )
         logger.info("Skipping uv init — project already initialized.")
+    else:
+        run_uv_init = True
 
     # Execution phase: perform mutations after all decisions are collected.
     if run_uv_init:

--- a/src/siesta/logger.py
+++ b/src/siesta/logger.py
@@ -152,8 +152,8 @@ class Logger(BaseLogger):
         return datetime.now().strftime("%H:%M:%S")
 
     @property
-    def prefix(self):
-        """Get the prefix for the log messages.
+    def prefix_text(self) -> str:
+        """Get the unstyled prefix text.
 
         The prefix includes the name of the logger and the current time.
 
@@ -169,8 +169,34 @@ class Logger(BaseLogger):
                 prefix += f" | {self.now()}"
         else:
             prefix += self.now()
+        return prefix
+
+    @property
+    def prefix(self) -> str:
+        """Get the Rich-formatted prefix for log messages.
+
+        Returns
+        -------
+        str
+            The Rich-formatted prefix.
+        """
+        prefix = self.prefix_text
         if prefix:
             return rf"[grey50 bold]\[{prefix}][/grey50 bold] "
+        return prefix
+
+    @property
+    def questionary_prefix(self) -> str:
+        """Get the plain-text prefix for questionary prompts.
+
+        Returns
+        -------
+        str
+            The plain-text prefix.
+        """
+        prefix = self.prefix_text
+        if prefix:
+            return f"[{prefix}] "
         return prefix
 
     def prompt(self, message: str, default: str | None = None) -> str:
@@ -194,7 +220,7 @@ class Logger(BaseLogger):
             If the prompt is cancelled (for example with Ctrl+C).
         """
         response = questionary.text(
-            f"{self.prefix}{message}",
+            f"{self.questionary_prefix}{message}",
             default=default if default is not None else "",
         ).ask()
         if response is None:
@@ -222,7 +248,7 @@ class Logger(BaseLogger):
             If the prompt is cancelled (for example with Ctrl+C).
         """
         response = questionary.confirm(
-            f"{self.prefix}{message}",
+            f"{self.questionary_prefix}{message}",
             default=default,
         ).ask()
         if response is None:
@@ -250,7 +276,7 @@ class Logger(BaseLogger):
             If the prompt is cancelled (for example with Ctrl+C).
         """
         response = questionary.checkbox(
-            f"{self.prefix}{message}", choices=choices
+            f"{self.questionary_prefix}{message}", choices=choices
         ).ask()
         if response is None:
             raise KeyboardInterrupt()
@@ -276,7 +302,9 @@ class Logger(BaseLogger):
         KeyboardInterrupt
             If the prompt is cancelled (for example with Ctrl+C).
         """
-        response = questionary.select(f"{self.prefix}{message}", choices=choices).ask()
+        response = questionary.select(
+            f"{self.questionary_prefix}{message}", choices=choices
+        ).ask()
         if response is None:
             raise KeyboardInterrupt()
         return response

--- a/src/siesta/logger.py
+++ b/src/siesta/logger.py
@@ -275,6 +275,8 @@ class Logger(BaseLogger):
         KeyboardInterrupt
             If the prompt is cancelled (for example with Ctrl+C).
         """
+        if not choices:
+            return []
         response = questionary.checkbox(
             f"{self.questionary_prefix}{message}", choices=choices
         ).ask()

--- a/src/siesta/utils/agents.py
+++ b/src/siesta/utils/agents.py
@@ -69,6 +69,39 @@ def available_constitutions() -> list[str]:
     return sorted(p.name for p in CONSTITUTIONS_DIR.iterdir() if p.is_dir())
 
 
+def _display_path(path: Path | str) -> str:
+    """Return a filesystem path as a CWD-relative display string.
+
+    Parameters
+    ----------
+    path : Path | str
+        Filesystem path to show in CLI prompts and summaries.
+
+    Returns
+    -------
+    str
+        ``path`` rendered relative to the current working directory.
+    """
+    cwd = Path.cwd()
+    target = Path(path)
+    if not target.is_absolute():
+        target = cwd / target
+
+    if target.anchor != cwd.anchor:
+        return str(target)
+
+    cwd_parts = cwd.parts
+    target_parts = target.parts
+    common = 0
+    for cwd_part, target_part in zip(cwd_parts, target_parts, strict=False):
+        if cwd_part != target_part:
+            break
+        common += 1
+
+    parents = [".."] * (len(cwd_parts) - common)
+    return str(Path(*parents, *target_parts[common:]))
+
+
 # ---------------------------------------------------------------------------
 # Provider + scope resolution
 # ---------------------------------------------------------------------------
@@ -114,6 +147,24 @@ def resolve_scope(local: bool, global_: bool) -> str:
     if local and global_:
         logger.abort("Cannot use both --local and --global.")
     return "global" if global_ else "local"
+
+
+def scope_display_label(scope: str) -> str:
+    """Return a human-readable Asset Scope label for CLI messages.
+
+    Parameters
+    ----------
+    scope : str
+        ``"local"`` or ``"global"``.
+
+    Returns
+    -------
+    str
+        Scope label including a short parenthetical explanation.
+    """
+    if scope == "global":
+        return "global (user home)"
+    return "local (current repository)"
 
 
 def base_dir(provider: str, scope: str) -> Path:
@@ -300,6 +351,7 @@ def resolve_selection(
     available: list[str],
     interactive: bool,
     kind: str,
+    scope: str,
 ) -> list[str]:
     """Resolve the final list of catalog items to install.
 
@@ -319,6 +371,8 @@ def resolve_selection(
         Whether ``-i``/``--interactive`` was passed.
     kind : str
         Human-readable kind label used in messages (``"skill"`` or ``"rule"``).
+    scope : str
+        Asset Scope (``"local"`` or ``"global"``) shown in the selection prompt.
 
     Returns
     -------
@@ -343,7 +397,10 @@ def resolve_selection(
         logger.abort(
             f"No {kind}s specified. Pass names, --all, or use -i for interactive mode."
         )
-    return logger.checkbox(f"Select {kind}s to add:", available)
+    if not available:
+        return []
+    prompt = f"Select {kind}s to add — {scope_display_label(scope)}:"
+    return logger.checkbox(prompt, available)
 
 
 # ---------------------------------------------------------------------------
@@ -551,9 +608,9 @@ def install_skill(
             force=force,
             backup=backup,
             interactive=interactive,
-            label=f"{provider}: {dest}",
+            label=f"{provider}: {_display_path(dest)}",
         )
-        _record(summary, action, str(dest))
+        _record(summary, action, _display_path(dest))
     return summary
 
 
@@ -601,9 +658,9 @@ def install_rule(
             force=force,
             backup=backup,
             interactive=interactive,
-            label=f"{provider}: {dest}",
+            label=f"{provider}: {_display_path(dest)}",
         )
-        _record(summary, action, str(dest))
+        _record(summary, action, _display_path(dest))
     return summary
 
 
@@ -673,7 +730,7 @@ def install_constitution(
         interactive=interactive,
         label="AGENTS.md",
     )
-    _record(summary, action, str(agents_dest))
+    _record(summary, action, _display_path(agents_dest))
     if action != "skip":
         logger.info(
             "AGENTS.md written (Cursor compatibility; not required by Claude itself)."
@@ -693,7 +750,7 @@ def install_constitution(
             interactive=False,
             label="CLAUDE.md",
         )
-        _record(summary, action, str(claude_dest))
+        _record(summary, action, _display_path(claude_dest))
     else:
         existing = claude_dest.read_text(encoding="utf-8")
         if IMPORT_LINE in existing:
@@ -749,7 +806,7 @@ def _handle_claude_import(
 
     if do_prepend:
         claude_dest.write_text(f"{IMPORT_LINE}\n\n{existing}", encoding="utf-8")
-        summary["written"].append(str(claude_dest) + " (import prepended)")
+        summary["written"].append(_display_path(claude_dest) + " (import prepended)")
 
 
 # ---------------------------------------------------------------------------
@@ -919,4 +976,484 @@ def print_summary(summary: dict[str, list[str]]) -> None:
         for path in skipped:
             logger.warning(f"Skipped (already exists): {path}")
     if not written and not backed_up and not skipped:
+        logger.info("Nothing to do.")
+
+
+# ---------------------------------------------------------------------------
+# Installed asset detection + removal
+# ---------------------------------------------------------------------------
+
+
+def detect_installed_skills(providers: list[str], scope: str) -> list[str]:
+    """Return sorted names of installed Skills for the given Providers and scope.
+
+    Parameters
+    ----------
+    providers : list[str]
+        Target Providers (``"cursor"`` and/or ``"claude"``).
+    scope : str
+        ``"local"`` or ``"global"``.
+
+    Returns
+    -------
+    list[str]
+        Sorted skill names found under any selected Provider.
+    """
+    names: set[str] = set()
+    for provider in providers:
+        skills_dir = base_dir(provider, scope) / "skills"
+        if not skills_dir.is_dir():
+            continue
+        for child in skills_dir.iterdir():
+            if child.is_dir():
+                names.add(child.name)
+    return sorted(names)
+
+
+def asset_search_paths(providers: list[str], scope: str, kind: str) -> list[str]:
+    """Return display paths scanned when detecting installed assets.
+
+    Parameters
+    ----------
+    providers : list[str]
+        Target Providers (``"cursor"`` and/or ``"claude"``).
+    scope : str
+        ``"local"`` or ``"global"``.
+    kind : str
+        Asset kind label (``"skill"`` or ``"rule"``).
+
+    Returns
+    -------
+    list[str]
+        CWD-relative paths to each Provider's skills or rules directory.
+    """
+    subdir = "skills" if kind == "skill" else "rules"
+    return [_display_path(base_dir(provider, scope) / subdir) for provider in providers]
+
+
+def detect_installed_rules(providers: list[str], scope: str) -> list[str]:
+    """Return sorted names of installed Rules for the given Providers and scope.
+
+    Parameters
+    ----------
+    providers : list[str]
+        Target Providers (``"cursor"`` and/or ``"claude"``).
+    scope : str
+        ``"local"`` or ``"global"``.
+
+    Returns
+    -------
+    list[str]
+        Sorted rule names (without extension) found under any selected Provider.
+    """
+    names: set[str] = set()
+    for provider in providers:
+        rules_dir = base_dir(provider, scope) / "rules"
+        if not rules_dir.is_dir():
+            continue
+        suffix = ".mdc" if provider == "cursor" else ".md"
+        for child in rules_dir.iterdir():
+            if child.is_file() and child.name.endswith(suffix):
+                names.add(child.name[: -len(suffix)])
+    return sorted(names)
+
+
+def constitution_paths(
+    providers: list[str], scope: str
+) -> tuple[Path | None, Path | None]:
+    """Return Constitution file paths for the selected Providers and scope.
+
+    Parameters
+    ----------
+    providers : list[str]
+        Target Providers.
+    scope : str
+        ``"local"`` or ``"global"``.
+
+    Returns
+    -------
+    tuple[Path | None, Path | None]
+        ``(agents_path, claude_path)`` where either entry may be ``None`` when
+        not applicable for the selected Provider/scope combination.
+    """
+    if providers == ["cursor"] and scope == "global":
+        return None, None
+
+    if scope == "local":
+        agents_path = Path.cwd() / "AGENTS.md"
+        claude_path = Path.cwd() / "CLAUDE.md" if "claude" in providers else None
+        return agents_path, claude_path
+
+    agents_path = Path.home() / ".claude" / "AGENTS.md"
+    claude_path = (
+        Path.home() / ".claude" / "CLAUDE.md" if "claude" in providers else None
+    )
+    return agents_path, claude_path
+
+
+def resolve_remove_selection(
+    names: list[str],
+    detected: list[str],
+    interactive: bool,
+    kind: str,
+    providers: list[str],
+    scope: str,
+) -> list[str]:
+    """Resolve which installed asset names to consider for removal.
+
+    Follows the same Input Precedence as :func:`resolve_selection`: explicit
+    names win; otherwise an interactive checkbox is shown on a TTY (or the
+    command aborts when stdin is not a tty).
+
+    Parameters
+    ----------
+    names : list[str]
+        Explicit names from the CLI.
+    detected : list[str]
+        Names detected on disk for the selected Providers and scope.
+    interactive : bool
+        Whether ``-i``/``--interactive`` was passed.
+    kind : str
+        Human-readable kind label (``"skill"`` or ``"rule"``).
+    providers : list[str]
+        Target Providers used for search-path disclosure in abort messages.
+    scope : str
+        Asset Scope (``"local"`` or ``"global"``) for search-path disclosure.
+
+    Returns
+    -------
+    list[str]
+        Asset names to evaluate for removal (may be empty).
+    """
+    search_paths = asset_search_paths(providers, scope, kind)
+    searching = ", ".join(search_paths)
+    scope_label = scope_display_label(scope)
+
+    if names:
+        missing = [n for n in names if n not in detected]
+        if missing:
+            logger.abort(
+                f"No installed {kind}(s) found: {missing}. "
+                f"Scope: {scope_label}. "
+                f"Searching: {searching}. "
+                f"Detected: {detected or '(none)'}"
+            )
+        return list(names)
+
+    if not sys.stdin.isatty():
+        if interactive:
+            logger.abort("Interactive selection requires a terminal (no TTY).")
+        logger.abort(
+            f"No {kind}s specified. Pass names to remove, or use -i for "
+            f"interactive mode.\n"
+            f"Scope: {scope_label}\n"
+            f"Searching: {searching}\n"
+            f"Detected: {detected or '(none)'}"
+        )
+    if not detected:
+        logger.info(
+            f"No installed {kind}s found.\n"
+            f"Scope: {scope_label}\n"
+            f"Searching: {searching}"
+        )
+        return []
+    prompt = f"Select {kind}s to remove — {scope_label}:"
+    return logger.checkbox(prompt, detected)
+
+
+def collect_confirmed_removals(
+    candidates: list[tuple[str, Path]],
+) -> tuple[list[Path], list[str]]:
+    """Confirm each removal candidate before any Mutation.
+
+    Parameters
+    ----------
+    candidates : list[tuple[str, Path]]
+        ``(display_label, path)`` pairs proposed for removal.
+
+    Returns
+    -------
+    tuple[list[Path], list[str]]
+        Confirmed paths and skipped display labels.
+    """
+    confirmed: list[Path] = []
+    skipped: list[str] = []
+    for label, path in candidates:
+        if logger.confirm(f"Remove {label}?"):
+            confirmed.append(path)
+        else:
+            skipped.append(label)
+    return confirmed, skipped
+
+
+def _catalog_agents_md_contents() -> set[str]:
+    """Return the exact ``AGENTS.md`` contents of every bundled Constitution."""
+    contents: set[str] = set()
+    for name in available_constitutions():
+        src = Path(str(CONSTITUTIONS_DIR / name / "AGENTS.md"))
+        contents.add(src.read_text(encoding="utf-8"))
+    return contents
+
+
+def _claude_md_is_import_stub(content: str) -> bool:
+    """Return whether *content* is only the ``@AGENTS.md`` import stub."""
+    lines = [line.strip() for line in content.splitlines() if line.strip()]
+    return lines == [IMPORT_LINE]
+
+
+def _strip_agents_import(content: str) -> str:
+    """Remove ``@AGENTS.md`` import lines from *content*, preserving the rest."""
+    kept = [line for line in content.splitlines() if line.strip() != IMPORT_LINE]
+    return "\n".join(kept).strip("\n")
+
+
+def remove_path(path: Path, *, backup: bool = False) -> str:
+    """Remove a file or directory, optionally backing it up first.
+
+    Parameters
+    ----------
+    path : Path
+        Path to remove.
+    backup : bool, optional
+        When ``True``, rename to ``<name>.bak`` before deletion.
+
+    Returns
+    -------
+    str
+        ``"removed"`` or ``"backed_up"``.
+    """
+    if backup:
+        _apply_backup(path)
+        return "backed_up"
+    if path.is_dir():
+        shutil.rmtree(path)
+    else:
+        path.unlink()
+    return "removed"
+
+
+def _record_removal(summary: dict[str, list[str]], action: str, path: str) -> None:
+    """Record a removal action in the summary dict."""
+    if action == "removed":
+        summary["removed"].append(path)
+    elif action == "backed_up":
+        summary["backed_up"].append(path)
+    elif action == "skipped":
+        summary["skipped"].append(path)
+
+
+def remove_skill(
+    name: str,
+    providers: list[str],
+    scope: str,
+    *,
+    backup: bool = False,
+) -> dict[str, list[str]]:
+    """Remove a single skill for every requested Provider (paths pre-confirmed).
+
+    Parameters
+    ----------
+    name : str
+        Skill name.
+    providers : list[str]
+        Target Providers.
+    scope : str
+        ``"local"`` or ``"global"``.
+    backup : bool, optional
+        Back up before removing.
+
+    Returns
+    -------
+    dict[str, list[str]]
+        ``{"removed": [...], "skipped": [...], "backed_up": [...]}``
+    """
+    summary: dict[str, list[str]] = {"removed": [], "skipped": [], "backed_up": []}
+    for provider in providers:
+        dest = skill_target(provider, scope, name)
+        if not dest.exists():
+            continue
+        action = remove_path(dest, backup=backup)
+        _record_removal(summary, action, _display_path(dest))
+    return summary
+
+
+def remove_rule(
+    name: str,
+    providers: list[str],
+    scope: str,
+    *,
+    backup: bool = False,
+) -> dict[str, list[str]]:
+    """Remove a single rule for every requested Provider (paths pre-confirmed).
+
+    Parameters
+    ----------
+    name : str
+        Rule name (without extension).
+    providers : list[str]
+        Target Providers.
+    scope : str
+        ``"local"`` or ``"global"``.
+    backup : bool, optional
+        Back up before removing.
+
+    Returns
+    -------
+    dict[str, list[str]]
+        ``{"removed": [...], "skipped": [...], "backed_up": [...]}``
+    """
+    summary: dict[str, list[str]] = {"removed": [], "skipped": [], "backed_up": []}
+    for provider in providers:
+        dest = rule_target(provider, scope, name)
+        if not dest.exists():
+            continue
+        action = remove_path(dest, backup=backup)
+        _record_removal(summary, action, _display_path(dest))
+    return summary
+
+
+def remove_constitution_file(
+    path: Path,
+    *,
+    force: bool = False,
+    backup: bool = False,
+) -> tuple[str, str]:
+    """Apply conservative removal logic to a Constitution file.
+
+    Parameters
+    ----------
+    path : Path
+        ``AGENTS.md`` or ``CLAUDE.md`` path (must exist; caller confirms first).
+    force : bool, optional
+        Allow removing user-authored content after confirmation.
+    backup : bool, optional
+        Back up before whole-file removal or partial rewrite.
+
+    Returns
+    -------
+    tuple[str, str]
+        ``(action, display_path)`` where *action* is ``"removed"``, ``"backed_up"``,
+        ``"modified"``, or ``"skipped"``.
+    """
+    display = _display_path(path)
+    content = path.read_text(encoding="utf-8")
+
+    if path.name == "AGENTS.md":
+        if content not in _catalog_agents_md_contents() and not force:
+            return "skipped", display
+        if backup:
+            _apply_backup(path)
+            return "backed_up", display
+        path.unlink()
+        return "removed", display
+
+    # CLAUDE.md
+    if IMPORT_LINE not in content:
+        if not force:
+            return "skipped", display
+        if backup:
+            _apply_backup(path)
+            return "backed_up", display
+        path.unlink()
+        return "removed", display
+
+    if _claude_md_is_import_stub(content):
+        if backup:
+            _apply_backup(path)
+            return "backed_up", display
+        path.unlink()
+        return "removed", display
+
+    new_content = _strip_agents_import(content)
+    if backup:
+        _apply_backup(path)
+    path.write_text(new_content + ("\n" if new_content else ""), encoding="utf-8")
+    return "modified", display + " (import removed)"
+
+
+def remove_constitution(
+    providers: list[str],
+    scope: str,
+    *,
+    force: bool = False,
+    backup: bool = False,
+    confirmed_agents: bool = False,
+    confirmed_claude: bool = False,
+) -> dict[str, list[str]]:
+    """Remove Constitution files confirmed during the Prompt Collection Phase.
+
+    Parameters
+    ----------
+    providers : list[str]
+        Target Providers.
+    scope : str
+        ``"local"`` or ``"global"``.
+    force : bool, optional
+        Allow removing non-catalog/user-authored Constitution content.
+    backup : bool, optional
+        Back up before removing or rewriting files.
+    confirmed_agents : bool, optional
+        Whether the user confirmed ``AGENTS.md`` removal.
+    confirmed_claude : bool, optional
+        Whether the user confirmed ``CLAUDE.md`` removal/modification.
+
+    Returns
+    -------
+    dict[str, list[str]]
+        ``{"removed": [...], "skipped": [...], "backed_up": [...]}``
+    """
+    summary: dict[str, list[str]] = {"removed": [], "skipped": [], "backed_up": []}
+
+    if providers == ["cursor"] and scope == "global":
+        logger.warning(
+            "Constitution is project-scoped for Cursor; nothing to do globally. "
+            "Tip: use --local (default) or --claude to target Claude's global ~/.claude/."
+        )
+        return summary
+
+    agents_path, claude_path = constitution_paths(providers, scope)
+
+    if confirmed_agents and agents_path and agents_path.exists():
+        action, display = remove_constitution_file(
+            agents_path, force=force, backup=backup
+        )
+        if action == "modified":
+            summary["removed"].append(display)
+        else:
+            _record_removal(summary, action, display)
+
+    if confirmed_claude and claude_path and claude_path.exists():
+        action, display = remove_constitution_file(
+            claude_path, force=force, backup=backup
+        )
+        if action == "modified":
+            summary["removed"].append(display)
+        else:
+            _record_removal(summary, action, display)
+
+    return summary
+
+
+def print_removal_summary(summary: dict[str, list[str]]) -> None:
+    """Print a Rich removal summary.
+
+    Parameters
+    ----------
+    summary : dict[str, list[str]]
+        ``{"removed": [...], "skipped": [...], "backed_up": [...]}``
+    """
+    removed = summary.get("removed", [])
+    skipped = summary.get("skipped", [])
+    backed_up = summary.get("backed_up", [])
+
+    if removed:
+        for path in removed:
+            logger.success(f"Removed: {path}")
+    if backed_up:
+        for path in backed_up:
+            logger.info(f"Backed up + removed: {path}")
+    if skipped:
+        for path in skipped:
+            logger.warning(f"Skipped: {path}")
+    if not removed and not backed_up and not skipped:
         logger.info("Nothing to do.")

--- a/src/siesta/utils/agents.py
+++ b/src/siesta/utils/agents.py
@@ -1238,6 +1238,8 @@ def _record_removal(summary: dict[str, list[str]], action: str, path: str) -> No
         summary["backed_up"].append(path)
     elif action == "skipped":
         summary["skipped"].append(path)
+    elif action == "modified":
+        summary["modified"].append(path)
 
 
 def remove_skill(
@@ -1338,7 +1340,7 @@ def remove_constitution_file(
 
     if path.name == "AGENTS.md":
         if content not in _catalog_agents_md_contents() and not force:
-            return "skipped", display
+            return "skipped", display + " (user-authored; pass --force to remove)"
         if backup:
             _apply_backup(path)
             return "backed_up", display
@@ -1348,7 +1350,7 @@ def remove_constitution_file(
     # CLAUDE.md
     if IMPORT_LINE not in content:
         if not force:
-            return "skipped", display
+            return "skipped", display + " (user-authored; pass --force to remove)"
         if backup:
             _apply_backup(path)
             return "backed_up", display
@@ -1363,10 +1365,12 @@ def remove_constitution_file(
         return "removed", display
 
     new_content = _strip_agents_import(content)
+    suffix = " (import removed)"
     if backup:
         _apply_backup(path)
+        suffix = " (import removed; original backed up)"
     path.write_text(new_content + ("\n" if new_content else ""), encoding="utf-8")
-    return "modified", display + " (import removed)"
+    return "modified", display + suffix
 
 
 def remove_constitution(
@@ -1398,36 +1402,33 @@ def remove_constitution(
     Returns
     -------
     dict[str, list[str]]
-        ``{"removed": [...], "skipped": [...], "backed_up": [...]}``
+        ``{"removed": [...], "skipped": [...], "backed_up": [...], "modified": [...]}``
+        where ``"modified"`` holds files edited in place (e.g. a ``CLAUDE.md``
+        whose ``@AGENTS.md`` import was stripped while the body was kept).
     """
-    summary: dict[str, list[str]] = {"removed": [], "skipped": [], "backed_up": []}
+    summary: dict[str, list[str]] = {
+        "removed": [],
+        "skipped": [],
+        "backed_up": [],
+        "modified": [],
+    }
 
-    if providers == ["cursor"] and scope == "global":
-        logger.warning(
-            "Constitution is project-scoped for Cursor; nothing to do globally. "
-            "Tip: use --local (default) or --claude to target Claude's global ~/.claude/."
-        )
-        return summary
-
+    # constitution_paths returns (None, None) for the cursor/global combination,
+    # so no removal branch runs and an empty summary is returned. The user-facing
+    # warning for that case lives in the CLI command (remove_constitution_cmd).
     agents_path, claude_path = constitution_paths(providers, scope)
 
     if confirmed_agents and agents_path and agents_path.exists():
         action, display = remove_constitution_file(
             agents_path, force=force, backup=backup
         )
-        if action == "modified":
-            summary["removed"].append(display)
-        else:
-            _record_removal(summary, action, display)
+        _record_removal(summary, action, display)
 
     if confirmed_claude and claude_path and claude_path.exists():
         action, display = remove_constitution_file(
             claude_path, force=force, backup=backup
         )
-        if action == "modified":
-            summary["removed"].append(display)
-        else:
-            _record_removal(summary, action, display)
+        _record_removal(summary, action, display)
 
     return summary
 
@@ -1438,20 +1439,25 @@ def print_removal_summary(summary: dict[str, list[str]]) -> None:
     Parameters
     ----------
     summary : dict[str, list[str]]
-        ``{"removed": [...], "skipped": [...], "backed_up": [...]}``
+        ``{"removed": [...], "skipped": [...], "backed_up": [...], "modified": [...]}``
+        (``"modified"`` is optional and only present for constitution removals).
     """
     removed = summary.get("removed", [])
     skipped = summary.get("skipped", [])
     backed_up = summary.get("backed_up", [])
+    modified = summary.get("modified", [])
 
     if removed:
         for path in removed:
             logger.success(f"Removed: {path}")
+    if modified:
+        for path in modified:
+            logger.success(f"Updated: {path}")
     if backed_up:
         for path in backed_up:
             logger.info(f"Backed up + removed: {path}")
     if skipped:
         for path in skipped:
             logger.warning(f"Skipped: {path}")
-    if not removed and not backed_up and not skipped:
+    if not removed and not backed_up and not skipped and not modified:
         logger.info("Nothing to do.")

--- a/src/siesta/utils/agents.py
+++ b/src/siesta/utils/agents.py
@@ -1152,9 +1152,7 @@ def resolve_remove_selection(
         )
     if not detected:
         logger.info(
-            f"No installed {kind}s found.\n"
-            f"Scope: {scope_label}\n"
-            f"Searching: {searching}"
+            f"No installed {kind}s found.\nScope: {scope_label}\nSearching: {searching}"
         )
         return []
     prompt = f"Select {kind}s to remove — {scope_label}:"

--- a/src/siesta/utils/config.py
+++ b/src/siesta/utils/config.py
@@ -24,6 +24,7 @@ ROOT = importlib.resources.files(PACKAGE_NAME)
 """Root directory of the ``siesta`` package."""
 
 CLI_DEFAULTS = {
+    "uv_init": True,
     "deps": True,
     "as_main_deps": False,
     "precommit": True,
@@ -36,6 +37,7 @@ CLI_DEFAULTS = {
 }
 """Default values for the CLI when not in ``interactive`` mode.
 
+- ``uv_init``: Whether to initialize a ``uv`` project (``$ uv init``), by default ``True``.
 - ``deps``: Whether to install dependencies (dev &? docs), by default ``True``.
 - ``as_main_deps``: Whether to include docs dependencies in the main dependencies, by default ``False``.
 - ``precommit``: Whether to install pre-commit hooks, by default ``True``.

--- a/src/siesta/utils/project.py
+++ b/src/siesta/utils/project.py
@@ -161,7 +161,26 @@ def write_tests_infra(project_name: str) -> None:
     (tests_dir / "test_import.py").write_text(test_example)
 
 
-def add_ipdb_as_debugger():
+_IPDB_BLOCK = dedent(
+    """
+
+    try:
+        import os
+
+        import ipdb  # noqa: F401
+
+        # set ipdb as default debugger when calling `breakpoint()`
+        os.environ["PYTHONBREAKPOINT"] = "ipdb.set_trace"
+    except ImportError:
+        print(
+            "`ipdb` not available.",
+            "Consider adding it to your dev stack for a smoother debugging experience.",
+        )
+    """
+)
+
+
+def add_ipdb_as_debugger(overwrite: bool = False) -> None:
     """Set ``ipdb`` as default debugger to the project.
 
     This will set ``ipdb`` as default debugger when calling ``breakpoint()`` by setting the
@@ -176,26 +195,17 @@ def add_ipdb_as_debugger():
         [(i, len(str(i).split("/"))) for i in inits], key=lambda x: x[1]
     )[0][0]
 
-    first_init.write_text(
-        first_init.read_text()
-        + dedent(
-            """
+    existing = first_init.read_text()
+    if "PYTHONBREAKPOINT" in existing:
+        if not overwrite:
+            logger.warning("ipdb already configured. Skipping.")
+            return
+        # Remove the siesta-added block before re-appending.
+        # If the user has their own PYTHONBREAKPOINT setup (_IPDB_BLOCK not found), append anyway.
+        if _IPDB_BLOCK in existing:
+            existing = existing.replace(_IPDB_BLOCK, "")
 
-            try:
-                import os
-
-                import ipdb  # noqa: F401
-
-                # set ipdb as default debugger when calling `breakpoint()`
-                os.environ["PYTHONBREAKPOINT"] = "ipdb.set_trace"
-            except ImportError:
-                print(
-                    "`ipdb` not available.",
-                    "Consider adding it to your dev stack for a smoother debugging experience.",
-                )
-            """
-        )
-    )
+    first_init.write_text(existing + _IPDB_BLOCK)
 
 
 def download_python_gitignore() -> str:
@@ -207,9 +217,12 @@ def download_python_gitignore() -> str:
     return response.text
 
 
-def write_gitignore() -> None:
+def write_gitignore(overwrite: bool = False) -> None:
     """Write the gitignore file to the ``.gitignore`` file."""
     gitignore_path = Path(".gitignore")
+    if gitignore_path.exists() and not overwrite:
+        logger.warning(".gitignore already exists. Skipping.")
+        return
     python_gitignore = "\n".join(
         line.rstrip() for line in download_python_gitignore().splitlines()
     )

--- a/system-architecture.md
+++ b/system-architecture.md
@@ -33,7 +33,7 @@ graph TB
     subgraph cli["CLI Domain Modules (command groups)"]
         DOCS["docs_app<br/>init / build / watch / open / update"]
         PROJ["project_app<br/>quickstart / setup-tests / tree"]
-        AGENTS["agents_app<br/>add-skill / add-rule<br/>add-constitution / quickstart"]
+        AGENTS["agents_app<br/>add skill / add rule / add constitution<br/>remove skill / remove rule / remove constitution / quickstart"]
         SELF["self_app<br/>version / update / *-github-pat<br/>show-deps / tab-completions"]
     end
 
@@ -154,6 +154,7 @@ relevant sections here:
 | [0002](docs/adr/0002-cli-package-modularization.md) | CLI Package Modularization | The `cli/` ↔ `utils/` layering |
 | [0003](docs/adr/0003-secret-handling-policy.md) | Secret Handling Policy | PAT handling in `self_app` / `github` |
 | [0004](docs/adr/0004-cross-provider-agent-assets.md) | Cross-Provider Agent Asset Installation | Providers, Asset Scope, Mirroring |
+| [0005](docs/adr/0005-nested-agent-asset-operations.md) | Nested Agent Asset Operations | `agents add` / `agents remove` command shape |
 
 ## Core Concepts
 
@@ -262,10 +263,15 @@ update check whose result is printed only on clean exit.
 
 ### `agents_app` + `utils/agents`
 **Location**: [agents_app.py](src/siesta/cli/agents_app.py), [utils/agents.py](src/siesta/utils/agents.py)
-The richest domain. Commands `add-skill`, `add-rule`, `add-constitution`, and `quickstart`
-are thin: they resolve scope/providers/selection (Validation Phase) then loop over
-installers (Execution Phase). All catalog discovery, path resolution, `.mdc` translation,
-the conflict-aware writer, and the `quickstart.yaml` loader live in `utils/agents`.
+The richest domain. Nested `add` and `remove` sub-apps expose per-kind commands
+(`skill`, `rule`, `constitution`); `quickstart` stays at the `agents` level.
+Add commands are thin: they resolve scope/providers/selection (Validation Phase)
+then loop over installers (Execution Phase). Remove commands follow a stricter
+validate → collect per-candidate confirmations → mutate flow: every detected
+removal target is confirmed through questionary before any file is deleted or
+rewritten. All catalog discovery, installed-asset detection, path resolution,
+``.mdc`` translation, the conflict-aware writer, conservative Constitution
+removal, and the `quickstart.yaml` loader live in `utils/agents`.
 `install_quickstart` validates every name in the **Quickstart Config** against the catalog
 before any write, then reuses the per-asset installers.
 

--- a/tests/test_cli/test_agents_app.py
+++ b/tests/test_cli/test_agents_app.py
@@ -262,6 +262,7 @@ class TestAddConstitution:
 
 class TestRemoveSkill:
     def test_removes_skill_after_confirmation(self, tmp_path_chdir, monkeypatch):
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
         monkeypatch.setattr(logger, "confirm", confirm_yes)
         run("agents", "add", "skill", "grill-with-docs", "--cursor", "--local")
         dest = tmp_path_chdir / ".cursor" / "skills" / "grill-with-docs"
@@ -270,6 +271,7 @@ class TestRemoveSkill:
         assert not dest.exists()
 
     def test_declining_confirmation_skips_removal(self, tmp_path_chdir, monkeypatch):
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
         monkeypatch.setattr(logger, "confirm", confirm_no)
         run("agents", "add", "skill", "grill-with-docs", "--cursor", "--local")
         dest = tmp_path_chdir / ".cursor" / "skills" / "grill-with-docs"
@@ -288,6 +290,7 @@ class TestRemoveSkill:
 
     def test_global_scope_targets_home(self, tmp_path, monkeypatch):
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
         monkeypatch.setattr(logger, "confirm", confirm_yes)
         (tmp_path / "repo").mkdir(exist_ok=True)
         monkeypatch.chdir(tmp_path / "repo")
@@ -297,6 +300,40 @@ class TestRemoveSkill:
         run("agents", "remove", "skill", "grill-with-docs", "--claude", "--global")
         assert not dest.exists()
 
+    def test_duplicate_names_confirmed_once(self, tmp_path_chdir, monkeypatch):
+        # A repeated name must be proposed and confirmed a single time.
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+        calls = {"n": 0}
+
+        def counting_confirm(_message, default=True):
+            calls["n"] += 1
+            return True
+
+        monkeypatch.setattr(logger, "confirm", counting_confirm)
+        run("agents", "add", "skill", "grill-with-docs", "--cursor", "--local")
+        dest = tmp_path_chdir / ".cursor" / "skills" / "grill-with-docs"
+        run(
+            "agents",
+            "remove",
+            "skill",
+            "grill-with-docs",
+            "grill-with-docs",
+            "--cursor",
+        )
+        assert calls["n"] == 1
+        assert not dest.exists()
+
+    def test_non_interactive_with_name_aborts_cleanly(
+        self, tmp_path_chdir, monkeypatch
+    ):
+        # Removal confirms each file, which needs a TTY; explicit names in a
+        # non-TTY shell must abort cleanly, not raise a bare KeyboardInterrupt.
+        run("agents", "add", "skill", "grill-with-docs", "--cursor", "--local")
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+        code = run("agents", "remove", "skill", "grill-with-docs", "--cursor")
+        assert code != 0
+        assert (tmp_path_chdir / ".cursor" / "skills" / "grill-with-docs").exists()
+
 
 # ---------------------------------------------------------------------------
 # remove rule
@@ -305,6 +342,7 @@ class TestRemoveSkill:
 
 class TestRemoveRule:
     def test_removes_rule_after_confirmation(self, tmp_path_chdir, monkeypatch):
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
         monkeypatch.setattr(logger, "confirm", confirm_yes)
         run("agents", "add", "rule", "python-docstrings", "--claude")
         dest = tmp_path_chdir / ".claude" / "rules" / "python-docstrings.md"
@@ -313,6 +351,7 @@ class TestRemoveRule:
         assert not dest.exists()
 
     def test_declining_confirmation_skips_removal(self, tmp_path_chdir, monkeypatch):
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
         monkeypatch.setattr(logger, "confirm", confirm_no)
         run("agents", "add", "rule", "python-docstrings", "--claude")
         dest = tmp_path_chdir / ".claude" / "rules" / "python-docstrings.md"
@@ -329,6 +368,7 @@ class TestRemoveConstitution:
     def test_removes_catalog_agents_after_confirmation(
         self, tmp_path_chdir, monkeypatch
     ):
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
         monkeypatch.setattr(logger, "confirm", confirm_yes)
         run("agents", "add", "constitution", "--cursor")
         agents = tmp_path_chdir / "AGENTS.md"
@@ -337,18 +377,21 @@ class TestRemoveConstitution:
         assert not agents.exists()
 
     def test_skips_user_agents_without_force(self, tmp_path_chdir, monkeypatch):
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
         monkeypatch.setattr(logger, "confirm", confirm_yes)
         (tmp_path_chdir / "AGENTS.md").write_text("my custom constitution")
         run("agents", "remove", "constitution", "--cursor")
         assert (tmp_path_chdir / "AGENTS.md").read_text() == "my custom constitution"
 
     def test_removes_user_agents_with_force(self, tmp_path_chdir, monkeypatch):
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
         monkeypatch.setattr(logger, "confirm", confirm_yes)
         (tmp_path_chdir / "AGENTS.md").write_text("my custom constitution")
         run("agents", "remove", "constitution", "--cursor", "--force")
         assert not (tmp_path_chdir / "AGENTS.md").exists()
 
     def test_removes_import_stub_claude_md(self, tmp_path_chdir, monkeypatch):
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
         monkeypatch.setattr(logger, "confirm", confirm_yes)
         run("agents", "add", "constitution", "--claude")
         claude = tmp_path_chdir / "CLAUDE.md"
@@ -359,12 +402,21 @@ class TestRemoveConstitution:
     def test_removes_only_import_from_mixed_claude_md(
         self, tmp_path_chdir, monkeypatch
     ):
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
         monkeypatch.setattr(logger, "confirm", confirm_yes)
         (tmp_path_chdir / "CLAUDE.md").write_text(f"{IMPORT_LINE}\n\nmy stuff")
         run("agents", "remove", "constitution", "--claude")
         content = (tmp_path_chdir / "CLAUDE.md").read_text()
         assert IMPORT_LINE not in content
         assert "my stuff" in content
+
+    def test_non_interactive_aborts_cleanly(self, tmp_path_chdir, monkeypatch):
+        # An existing constitution file in a non-TTY shell must abort cleanly.
+        (tmp_path_chdir / "AGENTS.md").write_text("my custom constitution")
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+        code = run("agents", "remove", "constitution", "--cursor")
+        assert code != 0
+        assert (tmp_path_chdir / "AGENTS.md").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli/test_agents_app.py
+++ b/tests/test_cli/test_agents_app.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 from siesta.cli.main_app import app
 from siesta.utils.agents import IMPORT_LINE
+from siesta.utils.common import logger
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -26,26 +27,42 @@ def run(*args):
         return e.code if e.code is not None else 0
 
 
+def confirm_yes(_message: str, default: bool = True) -> bool:
+    """Auto-accept confirmation prompts in tests."""
+    return True
+
+
+def confirm_no(_message: str, default: bool = True) -> bool:
+    """Auto-decline confirmation prompts in tests."""
+    return False
+
+
 # ---------------------------------------------------------------------------
-# add-skill
+# add skill
 # ---------------------------------------------------------------------------
 
 
 class TestAddSkill:
     def test_installs_skill_cursor(self, tmp_path_chdir):
-        run("agents", "add-skill", "grill-with-docs", "--cursor", "--local")
+        run("agents", "add", "skill", "grill-with-docs", "--cursor", "--local")
         assert (
             tmp_path_chdir / ".cursor" / "skills" / "grill-with-docs" / "SKILL.md"
         ).exists()
 
+    def test_prints_skill_path_relative_to_cwd(self, tmp_path_chdir, capsys):
+        run("agents", "add", "skill", "grill-with-docs", "--cursor", "--local")
+        output = capsys.readouterr().out
+        assert "Written: .cursor/skills/grill-with-docs" in output
+        assert str(tmp_path_chdir) not in output
+
     def test_installs_skill_claude(self, tmp_path_chdir):
-        run("agents", "add-skill", "grill-with-docs", "--claude", "--local")
+        run("agents", "add", "skill", "grill-with-docs", "--claude", "--local")
         assert (
             tmp_path_chdir / ".claude" / "skills" / "grill-with-docs" / "SKILL.md"
         ).exists()
 
     def test_installs_skill_both_providers(self, tmp_path_chdir):
-        run("agents", "add-skill", "grill-with-docs", "--both", "--local")
+        run("agents", "add", "skill", "grill-with-docs", "--both", "--local")
         assert (
             tmp_path_chdir / ".cursor" / "skills" / "grill-with-docs" / "SKILL.md"
         ).exists()
@@ -56,71 +73,79 @@ class TestAddSkill:
     def test_all_flag_installs_all(self, tmp_path_chdir):
         from siesta.utils.agents import available_skills
 
-        run("agents", "add-skill", "--all", "--cursor")
+        run("agents", "add", "skill", "--all", "--cursor")
         for skill in available_skills():
             assert (tmp_path_chdir / ".cursor" / "skills" / skill).is_dir()
 
     def test_all_and_names_mutual_exclusion(self, tmp_path_chdir):
-        code = run("agents", "add-skill", "grill-with-docs", "--all", "--cursor")
+        code = run("agents", "add", "skill", "grill-with-docs", "--all", "--cursor")
         assert code != 0
 
     def test_unknown_skill_name_aborts(self, tmp_path_chdir):
-        code = run("agents", "add-skill", "nonexistent-skill", "--cursor")
+        code = run("agents", "add", "skill", "nonexistent-skill", "--cursor")
         assert code != 0
 
     def test_skips_existing_by_default(self, tmp_path_chdir):
         dest = tmp_path_chdir / ".cursor" / "skills" / "grill-with-docs"
         dest.mkdir(parents=True)
         (dest / "SKILL.md").write_text("mine")
-        run("agents", "add-skill", "grill-with-docs", "--cursor")
+        run("agents", "add", "skill", "grill-with-docs", "--cursor")
         assert (dest / "SKILL.md").read_text() == "mine"
 
     def test_force_overwrites_existing(self, tmp_path_chdir):
         dest = tmp_path_chdir / ".cursor" / "skills" / "grill-with-docs"
         dest.mkdir(parents=True)
         (dest / "SKILL.md").write_text("old")
-        run("agents", "add-skill", "grill-with-docs", "--cursor", "--force")
+        run("agents", "add", "skill", "grill-with-docs", "--cursor", "--force")
         assert (dest / "SKILL.md").read_text() != "old"
 
     def test_backup_creates_bak(self, tmp_path_chdir):
         dest = tmp_path_chdir / ".cursor" / "skills" / "grill-with-docs"
         dest.mkdir(parents=True)
         (dest / "SKILL.md").write_text("old")
-        run("agents", "add-skill", "grill-with-docs", "--cursor", "--force", "--backup")
+        run(
+            "agents",
+            "add",
+            "skill",
+            "grill-with-docs",
+            "--cursor",
+            "--force",
+            "--backup",
+        )
         bak = tmp_path_chdir / ".cursor" / "skills" / "grill-with-docs.bak"
         assert bak.is_dir()
 
     def test_no_op_when_no_args_non_interactive(self, tmp_path_chdir, monkeypatch):
         monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
-        code = run("agents", "add-skill")
+        code = run("agents", "add", "skill")
         assert code != 0
 
     def test_global_scope_writes_to_home(self, tmp_path, monkeypatch):
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         (tmp_path / "repo").mkdir(exist_ok=True)
         monkeypatch.chdir(tmp_path / "repo")
-        run("agents", "add-skill", "grill-with-docs", "--claude", "--global")
+        run("agents", "add", "skill", "grill-with-docs", "--claude", "--global")
         assert (
             tmp_path / ".claude" / "skills" / "grill-with-docs" / "SKILL.md"
         ).exists()
 
 
 # ---------------------------------------------------------------------------
-# add-rule
+# add rule
 # ---------------------------------------------------------------------------
 
 
 class TestAddRule:
     def test_cursor_rule_is_mdc(self, tmp_path_chdir):
-        run("agents", "add-rule", "python-docstrings", "--cursor")
+        run("agents", "add", "rule", "python-docstrings", "--cursor")
         assert (tmp_path_chdir / ".cursor" / "rules" / "python-docstrings.mdc").exists()
 
     def test_claude_rule_is_md(self, tmp_path_chdir):
-        run("agents", "add-rule", "python-docstrings", "--claude")
+        run("agents", "add", "rule", "python-docstrings", "--claude")
         assert (tmp_path_chdir / ".claude" / "rules" / "python-docstrings.md").exists()
 
     def test_claude_rule_translated_has_paths(self, tmp_path_chdir):
-        run("agents", "add-rule", "python-docstrings", "--claude")
+        run("agents", "add", "rule", "python-docstrings", "--claude")
         content = (
             tmp_path_chdir / ".claude" / "rules" / "python-docstrings.md"
         ).read_text()
@@ -128,7 +153,7 @@ class TestAddRule:
         assert '"**/*.py"' in content
 
     def test_cursor_rule_has_alwaysapply(self, tmp_path_chdir):
-        run("agents", "add-rule", "python-docstrings", "--cursor")
+        run("agents", "add", "rule", "python-docstrings", "--cursor")
         content = (
             tmp_path_chdir / ".cursor" / "rules" / "python-docstrings.mdc"
         ).read_text()
@@ -137,97 +162,209 @@ class TestAddRule:
     def test_all_flag(self, tmp_path_chdir):
         from siesta.utils.agents import available_rules
 
-        run("agents", "add-rule", "--all", "--cursor")
+        run("agents", "add", "rule", "--all", "--cursor")
         for rule in available_rules():
             assert (tmp_path_chdir / ".cursor" / "rules" / f"{rule}.mdc").exists()
 
     def test_unknown_rule_aborts(self, tmp_path_chdir):
-        code = run("agents", "add-rule", "nonexistent-rule", "--cursor")
+        code = run("agents", "add", "rule", "nonexistent-rule", "--cursor")
         assert code != 0
 
     def test_skips_existing_by_default(self, tmp_path_chdir):
         dest = tmp_path_chdir / ".cursor" / "rules" / "python-docstrings.mdc"
         dest.parent.mkdir(parents=True)
         dest.write_text("mine")
-        run("agents", "add-rule", "python-docstrings", "--cursor")
+        run("agents", "add", "rule", "python-docstrings", "--cursor")
         assert dest.read_text() == "mine"
 
     def test_force_overwrites(self, tmp_path_chdir):
         dest = tmp_path_chdir / ".cursor" / "rules" / "python-docstrings.mdc"
         dest.parent.mkdir(parents=True)
         dest.write_text("old")
-        run("agents", "add-rule", "python-docstrings", "--cursor", "--force")
+        run("agents", "add", "rule", "python-docstrings", "--cursor", "--force")
         assert dest.read_text() != "old"
 
 
 # ---------------------------------------------------------------------------
-# add-constitution
+# add constitution
 # ---------------------------------------------------------------------------
 
 
 class TestAddConstitution:
     def test_default_writes_agents_and_claude(self, tmp_path_chdir):
-        run("agents", "add-constitution")
+        run("agents", "add", "constitution")
         assert (tmp_path_chdir / "AGENTS.md").exists()
         assert (tmp_path_chdir / "CLAUDE.md").exists()
         assert (tmp_path_chdir / "CLAUDE.md").read_text().strip() == IMPORT_LINE
 
     def test_cursor_only_no_claude_md(self, tmp_path_chdir):
-        run("agents", "add-constitution", "--cursor")
+        run("agents", "add", "constitution", "--cursor")
         assert (tmp_path_chdir / "AGENTS.md").exists()
         assert not (tmp_path_chdir / "CLAUDE.md").exists()
 
     def test_claude_only_writes_both(self, tmp_path_chdir):
-        run("agents", "add-constitution", "--claude")
+        run("agents", "add", "constitution", "--claude")
         assert (tmp_path_chdir / "AGENTS.md").exists()
         assert (tmp_path_chdir / "CLAUDE.md").exists()
 
     def test_global_cursor_only_skips_with_warning(self, tmp_path, monkeypatch):
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
-        run("agents", "add-constitution", "--cursor", "--global")
+        run("agents", "add", "constitution", "--cursor", "--global")
         assert not (tmp_path / "AGENTS.md").exists()
 
     def test_global_claude_writes_to_dot_claude(self, tmp_path, monkeypatch):
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
-        run("agents", "add-constitution", "--claude", "--global")
+        run("agents", "add", "constitution", "--claude", "--global")
         assert (tmp_path / ".claude" / "AGENTS.md").exists()
         assert (tmp_path / ".claude" / "CLAUDE.md").exists()
 
     def test_unknown_constitution_aborts(self, tmp_path_chdir):
-        code = run("agents", "add-constitution", "nonexistent-constitution")
+        code = run("agents", "add", "constitution", "nonexistent-constitution")
         assert code != 0
 
     def test_existing_agents_skipped_by_default(self, tmp_path_chdir):
         (tmp_path_chdir / "AGENTS.md").write_text("mine")
-        run("agents", "add-constitution", "--cursor")
+        run("agents", "add", "constitution", "--cursor")
         assert (tmp_path_chdir / "AGENTS.md").read_text() == "mine"
 
     def test_force_overwrites_agents(self, tmp_path_chdir):
         (tmp_path_chdir / "AGENTS.md").write_text("old")
-        run("agents", "add-constitution", "--cursor", "--force")
+        run("agents", "add", "constitution", "--cursor", "--force")
         assert (tmp_path_chdir / "AGENTS.md").read_text() != "old"
 
     def test_claude_md_import_already_present_no_duplicate(self, tmp_path_chdir):
         (tmp_path_chdir / "CLAUDE.md").write_text(f"{IMPORT_LINE}\n\nmy stuff")
-        run("agents", "add-constitution", "--claude")
+        run("agents", "add", "constitution", "--claude")
         content = (tmp_path_chdir / "CLAUDE.md").read_text()
         assert content.count(IMPORT_LINE) == 1
 
     def test_force_prepends_import_to_existing_claude_md(self, tmp_path_chdir):
         (tmp_path_chdir / "CLAUDE.md").write_text("existing content")
-        run("agents", "add-constitution", "--claude", "--force")
+        run("agents", "add", "constitution", "--claude", "--force")
         content = (tmp_path_chdir / "CLAUDE.md").read_text()
         assert content.startswith(IMPORT_LINE)
         assert "existing content" in content
 
     def test_backup_flag_preserves_old_agents(self, tmp_path_chdir):
         (tmp_path_chdir / "AGENTS.md").write_text("old agents")
-        run("agents", "add-constitution", "--cursor", "--force", "--backup")
+        run("agents", "add", "constitution", "--cursor", "--force", "--backup")
         assert (tmp_path_chdir / "AGENTS.md.bak").read_text() == "old agents"
 
     def test_local_and_global_abort(self, tmp_path_chdir):
-        code = run("agents", "add-constitution", "--local", "--global")
+        code = run("agents", "add", "constitution", "--local", "--global")
         assert code != 0
+
+
+# ---------------------------------------------------------------------------
+# remove skill
+# ---------------------------------------------------------------------------
+
+
+class TestRemoveSkill:
+    def test_removes_skill_after_confirmation(self, tmp_path_chdir, monkeypatch):
+        monkeypatch.setattr(logger, "confirm", confirm_yes)
+        run("agents", "add", "skill", "grill-with-docs", "--cursor", "--local")
+        dest = tmp_path_chdir / ".cursor" / "skills" / "grill-with-docs"
+        assert dest.exists()
+        run("agents", "remove", "skill", "grill-with-docs", "--cursor")
+        assert not dest.exists()
+
+    def test_declining_confirmation_skips_removal(self, tmp_path_chdir, monkeypatch):
+        monkeypatch.setattr(logger, "confirm", confirm_no)
+        run("agents", "add", "skill", "grill-with-docs", "--cursor", "--local")
+        dest = tmp_path_chdir / ".cursor" / "skills" / "grill-with-docs"
+        run("agents", "remove", "skill", "grill-with-docs", "--cursor")
+        assert dest.exists()
+
+    def test_non_interactive_without_names_aborts(self, tmp_path_chdir, monkeypatch):
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+        code = run("agents", "remove", "skill")
+        assert code != 0
+
+    def test_missing_skill_aborts(self, tmp_path_chdir, monkeypatch):
+        monkeypatch.setattr(logger, "confirm", confirm_yes)
+        code = run("agents", "remove", "skill", "nonexistent-skill", "--cursor")
+        assert code != 0
+
+    def test_global_scope_targets_home(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(logger, "confirm", confirm_yes)
+        (tmp_path / "repo").mkdir(exist_ok=True)
+        monkeypatch.chdir(tmp_path / "repo")
+        run("agents", "add", "skill", "grill-with-docs", "--claude", "--global")
+        dest = tmp_path / ".claude" / "skills" / "grill-with-docs"
+        assert dest.exists()
+        run("agents", "remove", "skill", "grill-with-docs", "--claude", "--global")
+        assert not dest.exists()
+
+
+# ---------------------------------------------------------------------------
+# remove rule
+# ---------------------------------------------------------------------------
+
+
+class TestRemoveRule:
+    def test_removes_rule_after_confirmation(self, tmp_path_chdir, monkeypatch):
+        monkeypatch.setattr(logger, "confirm", confirm_yes)
+        run("agents", "add", "rule", "python-docstrings", "--claude")
+        dest = tmp_path_chdir / ".claude" / "rules" / "python-docstrings.md"
+        assert dest.exists()
+        run("agents", "remove", "rule", "python-docstrings", "--claude")
+        assert not dest.exists()
+
+    def test_declining_confirmation_skips_removal(self, tmp_path_chdir, monkeypatch):
+        monkeypatch.setattr(logger, "confirm", confirm_no)
+        run("agents", "add", "rule", "python-docstrings", "--claude")
+        dest = tmp_path_chdir / ".claude" / "rules" / "python-docstrings.md"
+        run("agents", "remove", "rule", "python-docstrings", "--claude")
+        assert dest.exists()
+
+
+# ---------------------------------------------------------------------------
+# remove constitution
+# ---------------------------------------------------------------------------
+
+
+class TestRemoveConstitution:
+    def test_removes_catalog_agents_after_confirmation(
+        self, tmp_path_chdir, monkeypatch
+    ):
+        monkeypatch.setattr(logger, "confirm", confirm_yes)
+        run("agents", "add", "constitution", "--cursor")
+        agents = tmp_path_chdir / "AGENTS.md"
+        assert agents.exists()
+        run("agents", "remove", "constitution", "--cursor")
+        assert not agents.exists()
+
+    def test_skips_user_agents_without_force(self, tmp_path_chdir, monkeypatch):
+        monkeypatch.setattr(logger, "confirm", confirm_yes)
+        (tmp_path_chdir / "AGENTS.md").write_text("my custom constitution")
+        run("agents", "remove", "constitution", "--cursor")
+        assert (tmp_path_chdir / "AGENTS.md").read_text() == "my custom constitution"
+
+    def test_removes_user_agents_with_force(self, tmp_path_chdir, monkeypatch):
+        monkeypatch.setattr(logger, "confirm", confirm_yes)
+        (tmp_path_chdir / "AGENTS.md").write_text("my custom constitution")
+        run("agents", "remove", "constitution", "--cursor", "--force")
+        assert not (tmp_path_chdir / "AGENTS.md").exists()
+
+    def test_removes_import_stub_claude_md(self, tmp_path_chdir, monkeypatch):
+        monkeypatch.setattr(logger, "confirm", confirm_yes)
+        run("agents", "add", "constitution", "--claude")
+        claude = tmp_path_chdir / "CLAUDE.md"
+        assert claude.exists()
+        run("agents", "remove", "constitution", "--claude")
+        assert not claude.exists()
+
+    def test_removes_only_import_from_mixed_claude_md(
+        self, tmp_path_chdir, monkeypatch
+    ):
+        monkeypatch.setattr(logger, "confirm", confirm_yes)
+        (tmp_path_chdir / "CLAUDE.md").write_text(f"{IMPORT_LINE}\n\nmy stuff")
+        run("agents", "remove", "constitution", "--claude")
+        content = (tmp_path_chdir / "CLAUDE.md").read_text()
+        assert IMPORT_LINE not in content
+        assert "my stuff" in content
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli/test_cli_package.py
+++ b/tests/test_cli/test_cli_package.py
@@ -9,11 +9,16 @@ from cyclopts import App
 
 from siesta.cli import main
 from siesta.cli.agents_app import (
+    add_app,
     add_constitution,
     add_rule,
     add_skill,
     agents_app,
     quickstart,
+    remove_app,
+    remove_constitution_cmd,
+    remove_rule_cmd,
+    remove_skill_cmd,
 )
 from siesta.cli.docs_app import build_docs, docs_app, init_docs
 from siesta.cli.main_app import app
@@ -89,19 +94,31 @@ def test_tab_completions_app_registers_leaf_commands():
 
 
 def test_agents_app_registers_commands():
-    assert _command_names(agents_app) == {
-        "add-skill",
-        "add-rule",
-        "add-constitution",
-        "quickstart",
-    }
+    assert _command_names(agents_app) == {"add", "remove", "quickstart"}
+
+
+def test_add_app_registers_leaf_commands():
+    assert _command_names(add_app) == {"skill", "rule", "constitution"}
+
+
+def test_remove_app_registers_leaf_commands():
+    assert _command_names(remove_app) == {"skill", "rule", "constitution"}
 
 
 def test_agents_app_exposes_command_callables():
     assert callable(add_skill)
     assert callable(add_rule)
     assert callable(add_constitution)
+    assert callable(remove_skill_cmd)
+    assert callable(remove_rule_cmd)
+    assert callable(remove_constitution_cmd)
     assert callable(quickstart)
+
+
+def test_agents_app_does_not_register_legacy_flat_commands():
+    assert "add-skill" not in _command_names(agents_app)
+    assert "add-rule" not in _command_names(agents_app)
+    assert "add-constitution" not in _command_names(agents_app)
 
 
 def test_domain_modules_expose_command_callables():

--- a/tests/test_cli/test_quickstart_project.py
+++ b/tests/test_cli/test_quickstart_project.py
@@ -1,8 +1,20 @@
 # Copyright 2025 Entalpic
+import io
 from pathlib import Path
 
 import siesta.cli.project_app as cli
 from siesta.cli.main_app import app
+
+# Steps to disable so a quickstart run exercises only the uv-init decision.
+_NO_FEATURE_FLAGS = [
+    "--no-deps",
+    "--no-precommit",
+    "--no-tests",
+    "--no-actions",
+    "--no-gitignore",
+    "--no-docs",
+    "--no-agents",
+]
 
 
 def test_quickstart_project(tmp_path_chdir, capture_output):
@@ -154,7 +166,7 @@ def test_quickstart_test_scaffold_uses_normalized_import(tmp_path_chdir):
 def test_quickstart_collects_decisions_before_mutations(tmp_path_chdir, monkeypatch):
     """Test quickstart collects prompts before any mutating command runs."""
     events: list[str] = []
-    prompts = iter([True, True, True, True, True, True, True, True, False])
+    prompts = iter([True, True, True, True, True, True, True, True, True, False])
 
     def fake_confirm(message: str, default: bool = True) -> bool:
         events.append(f"confirm:{message}")
@@ -334,7 +346,7 @@ def test_quickstart_interactive_respects_explicit_layout(tmp_path_chdir, monkeyp
     monkeypatch.setattr(cli, "tree_project", lambda *_args, **_kwargs: None)
 
     try:
-        app(["project", "quickstart", "-i", "--as-app"])
+        app(["project", "quickstart", "-i", "--as-app", "--uv-init"])
     except SystemExit as e:
         assert e.code == 0
 
@@ -428,6 +440,73 @@ def test_quickstart_installs_agents(tmp_path_chdir, capture_output):
     assert (tmp_path_chdir / "AGENTS.md").exists()
     assert (tmp_path_chdir / ".cursor" / "skills" / "grill-with-docs").is_dir()
     assert (tmp_path_chdir / ".cursor" / "rules" / "python-docstrings.mdc").exists()
+
+
+def test_quickstart_existing_uv_project_aborts_without_no_uv_init(
+    tmp_path_chdir, monkeypatch, capture_output
+):
+    """Non-TTY quickstart on an already-initialized project aborts unless opted out."""
+    (tmp_path_chdir / "pyproject.toml").write_text("[project]\nname = 'x'\n")
+    # Force a non-TTY environment so the uv-init conflict resolves to abort.
+    monkeypatch.setattr("sys.stdin", io.StringIO())
+    monkeypatch.setattr(cli, "get_project_name", lambda _interactive: "test_siesta")
+    monkeypatch.setattr(cli, "run_command", lambda *_args, **_kwargs: True)
+
+    code = None
+    with capture_output() as output:
+        try:
+            app(["project", "quickstart"])
+        except SystemExit as e:
+            code = e.code
+
+    assert code != 0
+    assert "uv project" in output.getvalue()
+
+
+def test_quickstart_existing_uv_project_skips_with_no_uv_init(
+    tmp_path_chdir, monkeypatch, capture_output
+):
+    """--no-uv-init lets a non-TTY quickstart proceed on an existing project."""
+    (tmp_path_chdir / "pyproject.toml").write_text("[project]\nname = 'x'\n")
+    monkeypatch.setattr("sys.stdin", io.StringIO())
+    commands: list[list[str]] = []
+    monkeypatch.setattr(cli, "get_project_name", lambda _interactive: "test_siesta")
+    monkeypatch.setattr(
+        cli, "run_command", lambda cmd, *_a, **_k: commands.append(cmd) or True
+    )
+    monkeypatch.setattr(cli, "tree_project", lambda *_args, **_kwargs: None)
+
+    code = None
+    with capture_output() as output:
+        try:
+            app(["project", "quickstart", "--no-uv-init", *_NO_FEATURE_FLAGS])
+        except SystemExit as e:
+            code = e.code
+
+    assert code == 0
+    # uv init must not run, and no fresh-directory warning (the project already exists).
+    assert not any(cmd[:2] == ["uv", "init"] for cmd in commands)
+    assert "Skipping uv init on a fresh directory" not in output.getvalue()
+
+
+def test_quickstart_no_uv_init_on_fresh_project_warns(
+    tmp_path_chdir, monkeypatch, capture_output
+):
+    """--no-uv-init on a fresh directory warns that later steps may fail."""
+    monkeypatch.setattr("sys.stdin", io.StringIO())
+    monkeypatch.setattr(cli, "get_project_name", lambda _interactive: "test_siesta")
+    monkeypatch.setattr(cli, "run_command", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(cli, "tree_project", lambda *_args, **_kwargs: None)
+
+    code = None
+    with capture_output() as output:
+        try:
+            app(["project", "quickstart", "--no-uv-init", *_NO_FEATURE_FLAGS])
+        except SystemExit as e:
+            code = e.code
+
+    assert code == 0
+    assert "Skipping uv init on a fresh directory" in output.getvalue()
 
 
 def test_quickstart_respects_no_agents(tmp_path_chdir, capture_output):

--- a/tests/test_cli/test_quickstart_project.py
+++ b/tests/test_cli/test_quickstart_project.py
@@ -190,11 +190,15 @@ def test_quickstart_collects_decisions_before_mutations(tmp_path_chdir, monkeypa
     monkeypatch.setattr(
         cli, "write_or_update_pre_commit_file", lambda: events.append("precommit_file")
     )
-    monkeypatch.setattr(cli, "add_ipdb_as_debugger", lambda overwrite=False: events.append("ipdb"))
+    monkeypatch.setattr(
+        cli, "add_ipdb_as_debugger", lambda overwrite=False: events.append("ipdb")
+    )
     monkeypatch.setattr(
         cli, "setup_tests", lambda **_kwargs: events.append("setup_tests")
     )
-    monkeypatch.setattr(cli, "write_gitignore", lambda overwrite=False: events.append("gitignore"))
+    monkeypatch.setattr(
+        cli, "write_gitignore", lambda overwrite=False: events.append("gitignore")
+    )
     monkeypatch.setattr(
         "siesta.cli.docs_app.init_docs",
         lambda **_kwargs: events.append("init_docs"),

--- a/tests/test_cli/test_quickstart_project.py
+++ b/tests/test_cli/test_quickstart_project.py
@@ -190,11 +190,11 @@ def test_quickstart_collects_decisions_before_mutations(tmp_path_chdir, monkeypa
     monkeypatch.setattr(
         cli, "write_or_update_pre_commit_file", lambda: events.append("precommit_file")
     )
-    monkeypatch.setattr(cli, "add_ipdb_as_debugger", lambda: events.append("ipdb"))
+    monkeypatch.setattr(cli, "add_ipdb_as_debugger", lambda overwrite=False: events.append("ipdb"))
     monkeypatch.setattr(
         cli, "setup_tests", lambda **_kwargs: events.append("setup_tests")
     )
-    monkeypatch.setattr(cli, "write_gitignore", lambda: events.append("gitignore"))
+    monkeypatch.setattr(cli, "write_gitignore", lambda overwrite=False: events.append("gitignore"))
     monkeypatch.setattr(
         "siesta.cli.docs_app.init_docs",
         lambda **_kwargs: events.append("init_docs"),
@@ -248,9 +248,9 @@ def test_quickstart_interactive_recommends_cli_defaults(tmp_path_chdir, monkeypa
     monkeypatch.setattr(cli, "run_command", lambda *_args, **_kwargs: True)
     monkeypatch.setattr(cli, "load_deps", lambda: {"dev": []})
     monkeypatch.setattr(cli, "write_or_update_pre_commit_file", lambda: None)
-    monkeypatch.setattr(cli, "add_ipdb_as_debugger", lambda: None)
+    monkeypatch.setattr(cli, "add_ipdb_as_debugger", lambda overwrite=False: None)
     monkeypatch.setattr(cli, "setup_tests", lambda **_kwargs: None)
-    monkeypatch.setattr(cli, "write_gitignore", lambda: None)
+    monkeypatch.setattr(cli, "write_gitignore", lambda overwrite=False: None)
     monkeypatch.setattr(cli, "tree_project", lambda *_args, **_kwargs: None)
 
     try:
@@ -283,9 +283,9 @@ def test_quickstart_interactive_recommends_dev_docs_deps(tmp_path_chdir, monkeyp
     monkeypatch.setattr(cli, "run_command", lambda *_args, **_kwargs: True)
     monkeypatch.setattr(cli, "load_deps", lambda: {"dev": []})
     monkeypatch.setattr(cli, "write_or_update_pre_commit_file", lambda: None)
-    monkeypatch.setattr(cli, "add_ipdb_as_debugger", lambda: None)
+    monkeypatch.setattr(cli, "add_ipdb_as_debugger", lambda overwrite=False: None)
     monkeypatch.setattr(cli, "setup_tests", lambda **_kwargs: None)
-    monkeypatch.setattr(cli, "write_gitignore", lambda: None)
+    monkeypatch.setattr(cli, "write_gitignore", lambda overwrite=False: None)
     monkeypatch.setattr(
         "siesta.cli.docs_app.init_docs",
         lambda **_kwargs: None,
@@ -396,9 +396,9 @@ def test_quickstart_fresh_project_delegates_docs_uv_detection(
     monkeypatch.setattr(cli, "run_command", lambda *_args, **_kwargs: True)
     monkeypatch.setattr(cli, "load_deps", lambda: {"dev": []})
     monkeypatch.setattr(cli, "write_or_update_pre_commit_file", lambda: None)
-    monkeypatch.setattr(cli, "add_ipdb_as_debugger", lambda: None)
+    monkeypatch.setattr(cli, "add_ipdb_as_debugger", lambda overwrite=False: None)
     monkeypatch.setattr(cli, "setup_tests", lambda **_kwargs: None)
-    monkeypatch.setattr(cli, "write_gitignore", lambda: None)
+    monkeypatch.setattr(cli, "write_gitignore", lambda overwrite=False: None)
     monkeypatch.setattr(
         "siesta.cli.docs_app.init_docs",
         lambda **kwargs: init_docs_kwargs.update(kwargs),

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -159,3 +159,11 @@ def test_confirm_secret_declines_eof(logger):
 def test_confirm_secret_declines_non_tty(logger):
     with patch("sys.stdin.isatty", return_value=False):
         assert logger.confirm_secret("Reveal secret?") is False
+
+
+def test_checkbox_empty_choices_skips_questionary(logger, monkeypatch):
+    def fail_checkbox(*_args, **_kwargs):
+        raise AssertionError("questionary.checkbox should not be called")
+
+    monkeypatch.setattr("siesta.logger.questionary.checkbox", fail_checkbox)
+    assert logger.checkbox("Select items:", []) == []

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -27,6 +27,9 @@ def test_prompt_uses_questionary_text(logger, monkeypatch):
 
     monkeypatch.setattr("siesta.logger.questionary.text", fake_text)
     assert logger.prompt("Project name", default="proj") == "value"
+    assert "[grey50 bold]" not in asked["message"]
+    assert "[/grey50 bold]" not in asked["message"]
+    assert asked["message"].startswith("[test | ")
     assert asked["message"].endswith("Project name")
     assert asked["default"] == "proj"
 
@@ -57,6 +60,9 @@ def test_confirm_uses_questionary_confirm(logger, monkeypatch):
 
     monkeypatch.setattr("siesta.logger.questionary.confirm", fake_confirm)
     assert logger.confirm("Continue?") is True
+    assert "[grey50 bold]" not in asked["message"]
+    assert "[/grey50 bold]" not in asked["message"]
+    assert asked["message"].startswith("[test | ")
     assert asked["message"].endswith("Continue?")
     assert asked["default"] is True
 

--- a/tests/test_utils/test_agents.py
+++ b/tests/test_utils/test_agents.py
@@ -11,26 +11,40 @@ import pytest
 from siesta.utils.agents import (
     DEFAULT_CONSTITUTION,
     IMPORT_LINE,
+    _display_path,
     _split_frontmatter,
     _split_globs,
+    asset_search_paths,
     available_constitutions,
     available_rules,
     available_skills,
     base_dir,
+    collect_confirmed_removals,
+    constitution_paths,
+    detect_installed_rules,
+    detect_installed_skills,
     install_constitution,
     install_quickstart,
     install_rule,
     install_skill,
     load_quickstart,
     mdc_to_claude,
+    remove_constitution,
+    remove_constitution_file,
+    remove_path,
+    remove_rule,
+    remove_skill,
     resolve_providers,
+    resolve_remove_selection,
     resolve_scope,
     resolve_selection,
+    scope_display_label,
     rule_target,
     skill_target,
     write_dir,
     write_file,
 )
+from siesta.utils.common import logger
 
 # ---------------------------------------------------------------------------
 # Catalog discovery
@@ -121,6 +135,22 @@ class TestBaseDir:
 
 
 class TestTargetPaths:
+    def test_display_path_is_relative_to_cwd(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        dest = tmp_path / ".cursor" / "rules" / "python-docstrings.mdc"
+        assert _display_path(dest) == str(
+            Path(".cursor") / "rules" / "python-docstrings.mdc"
+        )
+
+    def test_display_path_walks_up_to_paths_outside_cwd(self, tmp_path, monkeypatch):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        monkeypatch.chdir(repo)
+        dest = tmp_path / ".claude" / "skills" / "grill-with-docs"
+        assert _display_path(dest) == str(
+            Path("..") / ".claude" / "skills" / "grill-with-docs"
+        )
+
     def test_skill_target_cursor_local(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
         dest = skill_target("cursor", "local", "grill-with-docs")
@@ -266,32 +296,45 @@ class TestResolveSelection:
             ["python-docstrings", "mirror-providers"],
             False,
             "rule",
+            "local",
         )
         assert result == ["python-docstrings"]
 
     def test_all_flag_returns_all(self):
         available = ["a", "b", "c"]
-        result = resolve_selection([], True, available, False, "rule")
+        result = resolve_selection([], True, available, False, "rule", "local")
         assert result == available
 
     def test_names_and_all_aborts(self):
         with pytest.raises(SystemExit):
-            resolve_selection(["a"], True, ["a", "b"], False, "rule")
+            resolve_selection(["a"], True, ["a", "b"], False, "rule", "local")
 
     def test_unknown_name_aborts(self):
         with pytest.raises(SystemExit):
-            resolve_selection(["unknown"], False, ["a", "b"], False, "rule")
+            resolve_selection(["unknown"], False, ["a", "b"], False, "rule", "local")
 
     def test_non_interactive_no_stdin_aborts(self, monkeypatch):
         monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
         with pytest.raises(SystemExit):
-            resolve_selection([], False, ["a"], False, "rule")
+            resolve_selection([], False, ["a"], False, "rule", "local")
 
     def test_interactive_without_tty_aborts(self, monkeypatch):
         # Explicit -i with no terminal must abort, not fall through to a prompt.
         monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
         with pytest.raises(SystemExit):
-            resolve_selection([], False, ["a"], True, "rule")
+            resolve_selection([], False, ["a"], True, "rule", "local")
+
+    def test_checkbox_prompt_includes_scope(self, monkeypatch):
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+        prompts: list[str] = []
+
+        def capture_checkbox(message: str, choices: list[str]) -> list[str]:
+            prompts.append(message)
+            return choices
+
+        monkeypatch.setattr(logger, "checkbox", capture_checkbox)
+        resolve_selection([], False, ["a-skill"], False, "skill", "global")
+        assert prompts == ["Select skills to add — global (user home):"]
 
 
 # ---------------------------------------------------------------------------
@@ -389,7 +432,10 @@ class TestInstallSkill:
     def test_installs_for_both_providers(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
         summary = install_skill("grill-with-docs", ["cursor", "claude"], "local")
-        assert len(summary["written"]) == 2
+        assert summary["written"] == [
+            str(Path(".cursor") / "skills" / "grill-with-docs"),
+            str(Path(".claude") / "skills" / "grill-with-docs"),
+        ]
         assert (
             tmp_path / ".cursor" / "skills" / "grill-with-docs" / "SKILL.md"
         ).exists()
@@ -403,7 +449,7 @@ class TestInstallSkill:
         dest.mkdir(parents=True)
         (dest / "SKILL.md").write_text("existing")
         summary = install_skill("grill-with-docs", ["cursor"], "local")
-        assert str(dest) in summary["skipped"]
+        assert str(Path(".cursor") / "skills" / "grill-with-docs") in summary["skipped"]
         assert (dest / "SKILL.md").read_text() == "existing"
 
 
@@ -418,7 +464,9 @@ class TestInstallRule:
         summary = install_rule("python-docstrings", ["cursor"], "local")
         dest = tmp_path / ".cursor" / "rules" / "python-docstrings.mdc"
         assert dest.exists()
-        assert len(summary["written"]) == 1
+        assert summary["written"] == [
+            str(Path(".cursor") / "rules" / "python-docstrings.mdc")
+        ]
         content = dest.read_text()
         assert "alwaysApply" in content
 
@@ -452,10 +500,13 @@ class TestInstallRule:
 class TestInstallConstitution:
     def test_both_providers_local(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
-        install_constitution(DEFAULT_CONSTITUTION, ["cursor", "claude"], "local")
+        summary = install_constitution(
+            DEFAULT_CONSTITUTION, ["cursor", "claude"], "local"
+        )
         assert (tmp_path / "AGENTS.md").exists()
         assert (tmp_path / "CLAUDE.md").exists()
         assert (tmp_path / "CLAUDE.md").read_text().strip() == IMPORT_LINE
+        assert summary["written"] == ["AGENTS.md", "CLAUDE.md"]
 
     def test_cursor_only_writes_agents_md(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
@@ -519,12 +570,13 @@ class TestInstallConstitution:
     ):
         monkeypatch.chdir(tmp_path)
         (tmp_path / "CLAUDE.md").write_text("existing content")
-        install_constitution(
+        summary = install_constitution(
             DEFAULT_CONSTITUTION, ["claude"], "local", force=True, interactive=False
         )
         content = (tmp_path / "CLAUDE.md").read_text()
         assert content.startswith(IMPORT_LINE)
         assert "existing content" in content
+        assert "CLAUDE.md (import prepended)" in summary["written"]
 
     def test_agents_md_backed_up_with_backup_flag(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
@@ -569,3 +621,249 @@ class TestInstallQuickstart:
         )
         with pytest.raises(SystemExit):
             install_quickstart(["cursor"], "local")
+
+
+# ---------------------------------------------------------------------------
+# Detection + removal helpers
+# ---------------------------------------------------------------------------
+
+
+class TestDetectInstalled:
+    def test_detects_non_catalog_skill(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        custom = tmp_path / ".cursor" / "skills" / "custom-skill"
+        custom.mkdir(parents=True)
+        assert detect_installed_skills(["cursor"], "local") == ["custom-skill"]
+
+    def test_detects_non_catalog_rule(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        rules = tmp_path / ".claude" / "rules"
+        rules.mkdir(parents=True)
+        (rules / "custom-rule.md").write_text("# rule")
+        assert detect_installed_rules(["claude"], "local") == ["custom-rule"]
+
+    def test_returns_sorted_names(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        for name in ("z-skill", "a-skill"):
+            (tmp_path / ".cursor" / "skills" / name).mkdir(parents=True)
+        assert detect_installed_skills(["cursor"], "local") == ["a-skill", "z-skill"]
+
+
+class TestScopeDisplayLabel:
+    def test_local(self):
+        assert scope_display_label("local") == "local (current repository)"
+
+    def test_global(self):
+        assert scope_display_label("global") == "global (user home)"
+
+
+class TestAssetSearchPaths:
+    def test_local_cursor_skill_path(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        assert asset_search_paths(["cursor"], "local", "skill") == [
+            str(Path(".cursor") / "skills")
+        ]
+
+    def test_global_both_providers(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.chdir(tmp_path)
+        paths = asset_search_paths(["cursor", "claude"], "global", "rule")
+        assert paths == [
+            str(Path(".cursor") / "rules"),
+            str(Path(".claude") / "rules"),
+        ]
+
+
+class TestResolveRemoveSelection:
+    def test_explicit_missing_name_aborts(self, monkeypatch):
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+        with pytest.raises(SystemExit):
+            resolve_remove_selection(
+                ["missing"],
+                ["installed"],
+                False,
+                "skill",
+                ["cursor"],
+                "local",
+            )
+
+    def test_non_interactive_no_stdin_aborts(self, monkeypatch):
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+        messages: list[str] = []
+
+        def capture_abort(message: str) -> None:
+            messages.append(message)
+            raise SystemExit(1)
+
+        monkeypatch.setattr(logger, "abort", capture_abort)
+        with pytest.raises(SystemExit):
+            resolve_remove_selection(
+                [], ["installed"], False, "skill", ["cursor"], "global"
+            )
+        assert len(messages) == 1
+        assert "Scope: global (user home)" in messages[0]
+        assert "Searching:" in messages[0]
+        assert "Detected: ['installed']" in messages[0]
+
+    def test_interactive_without_tty_aborts(self, monkeypatch):
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+        with pytest.raises(SystemExit):
+            resolve_remove_selection(
+                [], ["installed"], True, "skill", ["cursor"], "local"
+            )
+
+    def test_tty_without_names_shows_checkbox(self, monkeypatch):
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+        prompts: list[str] = []
+
+        def capture_checkbox(message: str, choices: list[str]) -> list[str]:
+            prompts.append(message)
+            return choices
+
+        monkeypatch.setattr(logger, "checkbox", capture_checkbox)
+        result = resolve_remove_selection(
+            [], ["a-skill", "b-skill"], False, "skill", ["cursor"], "local"
+        )
+        assert result == ["a-skill", "b-skill"]
+        assert prompts == ["Select skills to remove — local (current repository):"]
+
+    def test_empty_detected_on_tty_skips_checkbox(self, monkeypatch):
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+        messages: list[str] = []
+
+        def fail_checkbox(_message: str, _choices: list[str]) -> list[str]:
+            raise AssertionError("checkbox should not be called when detected is empty")
+
+        monkeypatch.setattr(logger, "info", lambda msg: messages.append(msg))
+        monkeypatch.setattr(logger, "checkbox", fail_checkbox)
+        result = resolve_remove_selection(
+            [], [], False, "skill", ["cursor"], "local"
+        )
+        assert result == []
+        assert len(messages) == 1
+        assert "No installed skills found." in messages[0]
+        assert "Scope: local (current repository)" in messages[0]
+        assert "Searching:" in messages[0]
+
+
+class TestCollectConfirmedRemovals:
+    def test_accepts_and_declines(self, tmp_path, monkeypatch):
+        yes = tmp_path / "yes.txt"
+        no = tmp_path / "no.txt"
+        yes.write_text("yes")
+        no.write_text("no")
+
+        responses = iter([True, False])
+        monkeypatch.setattr(logger, "confirm", lambda _msg: next(responses))
+
+        confirmed, skipped = collect_confirmed_removals(
+            [("yes file", yes), ("no file", no)]
+        )
+        assert confirmed == [yes]
+        assert skipped == ["no file"]
+        assert yes.read_text() == "yes"
+        assert no.read_text() == "no"
+
+
+class TestRemovePath:
+    def test_backup_before_remove(self, tmp_path):
+        target = tmp_path / "out.txt"
+        target.write_text("data")
+        action = remove_path(target, backup=True)
+        assert action == "backed_up"
+        assert not target.exists()
+        assert (tmp_path / "out.txt.bak").read_text() == "data"
+
+
+class TestRemoveSkillRule:
+    def test_remove_skill(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        install_skill("grill-with-docs", ["cursor"], "local")
+        dest = tmp_path / ".cursor" / "skills" / "grill-with-docs"
+        assert dest.exists()
+        summary = remove_skill("grill-with-docs", ["cursor"], "local")
+        assert not dest.exists()
+        assert str(Path(".cursor") / "skills" / "grill-with-docs") in summary["removed"]
+
+    def test_remove_rule(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        install_rule("python-docstrings", ["claude"], "local")
+        dest = tmp_path / ".claude" / "rules" / "python-docstrings.md"
+        summary = remove_rule("python-docstrings", ["claude"], "local")
+        assert not dest.exists()
+        assert (
+            str(Path(".claude") / "rules" / "python-docstrings.md")
+            in summary["removed"]
+        )
+
+
+class TestRemoveConstitutionFile:
+    def test_removes_catalog_agents_md(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        install_constitution(DEFAULT_CONSTITUTION, ["cursor"], "local")
+        agents = tmp_path / "AGENTS.md"
+        action, _ = remove_constitution_file(agents)
+        assert action == "removed"
+        assert not agents.exists()
+
+    def test_skips_custom_agents_without_force(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        agents = tmp_path / "AGENTS.md"
+        agents.write_text("custom")
+        action, _ = remove_constitution_file(agents, force=False)
+        assert action == "skipped"
+        assert agents.exists()
+
+    def test_removes_custom_agents_with_force(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        agents = tmp_path / "AGENTS.md"
+        agents.write_text("custom")
+        action, _ = remove_constitution_file(agents, force=True)
+        assert action == "removed"
+        assert not agents.exists()
+
+    def test_deletes_import_stub_claude_md(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        claude = tmp_path / "CLAUDE.md"
+        claude.write_text(IMPORT_LINE)
+        action, _ = remove_constitution_file(claude)
+        assert action == "removed"
+        assert not claude.exists()
+
+    def test_strips_import_from_mixed_claude_md(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        claude = tmp_path / "CLAUDE.md"
+        claude.write_text(f"{IMPORT_LINE}\n\nbody")
+        action, display = remove_constitution_file(claude)
+        assert action == "modified"
+        assert "import removed" in display
+        assert IMPORT_LINE not in claude.read_text()
+        assert "body" in claude.read_text()
+
+
+class TestRemoveConstitution:
+    def test_confirmed_local_removal(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        install_constitution(DEFAULT_CONSTITUTION, ["cursor", "claude"], "local")
+        summary = remove_constitution(
+            ["cursor", "claude"],
+            "local",
+            confirmed_agents=True,
+            confirmed_claude=True,
+        )
+        assert not (tmp_path / "AGENTS.md").exists()
+        assert not (tmp_path / "CLAUDE.md").exists()
+        assert "AGENTS.md" in summary["removed"]
+        assert "CLAUDE.md" in summary["removed"]
+
+    def test_constitution_paths_local(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        agents, claude = constitution_paths(["cursor", "claude"], "local")
+        assert agents == tmp_path / "AGENTS.md"
+        assert claude == tmp_path / "CLAUDE.md"
+
+    def test_constitution_paths_global_claude(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        agents, claude = constitution_paths(["claude"], "global")
+        assert agents == tmp_path / ".claude" / "AGENTS.md"
+        assert claude == tmp_path / ".claude" / "CLAUDE.md"

--- a/tests/test_utils/test_agents.py
+++ b/tests/test_utils/test_agents.py
@@ -808,8 +808,10 @@ class TestRemoveConstitutionFile:
         monkeypatch.chdir(tmp_path)
         agents = tmp_path / "AGENTS.md"
         agents.write_text("custom")
-        action, _ = remove_constitution_file(agents, force=False)
+        action, display = remove_constitution_file(agents, force=False)
         assert action == "skipped"
+        # The skip reason must explain why a confirmed removal did nothing.
+        assert "pass --force to remove" in display
         assert agents.exists()
 
     def test_removes_custom_agents_with_force(self, tmp_path, monkeypatch):
@@ -853,6 +855,15 @@ class TestRemoveConstitution:
         assert not (tmp_path / "CLAUDE.md").exists()
         assert "AGENTS.md" in summary["removed"]
         assert "CLAUDE.md" in summary["removed"]
+
+    def test_stripped_claude_md_recorded_as_modified(self, tmp_path, monkeypatch):
+        # An edited-but-kept CLAUDE.md must not be reported as "removed".
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "CLAUDE.md").write_text(f"{IMPORT_LINE}\n\nbody")
+        summary = remove_constitution(["claude"], "local", confirmed_claude=True)
+        assert (tmp_path / "CLAUDE.md").exists()
+        assert summary["removed"] == []
+        assert any("CLAUDE.md" in entry for entry in summary["modified"])
 
     def test_constitution_paths_local(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)

--- a/tests/test_utils/test_agents.py
+++ b/tests/test_utils/test_agents.py
@@ -38,8 +38,8 @@ from siesta.utils.agents import (
     resolve_remove_selection,
     resolve_scope,
     resolve_selection,
-    scope_display_label,
     rule_target,
+    scope_display_label,
     skill_target,
     write_dir,
     write_file,
@@ -736,9 +736,7 @@ class TestResolveRemoveSelection:
 
         monkeypatch.setattr(logger, "info", lambda msg: messages.append(msg))
         monkeypatch.setattr(logger, "checkbox", fail_checkbox)
-        result = resolve_remove_selection(
-            [], [], False, "skill", ["cursor"], "local"
-        )
+        result = resolve_remove_selection([], [], False, "skill", ["cursor"], "local")
         assert result == []
         assert len(messages) == 1
         assert "No installed skills found." in messages[0]


### PR DESCRIPTION
## TL;DR

Restructure `siesta agents` into nested `add`/`remove` sub-apps with per-kind
commands, add safe interactive removal of installed assets, and make project
`quickstart` resolve all conflicts (including uv-init) up front so an aborted run
never leaves a half-mutated project.

## Breaking changes 🔥

- **🟠 Flat `agents add-*` commands removed**: `siesta agents add-skill`,
  `add-rule`, and `add-constitution` are gone, replaced by nested
  `siesta agents add skill|rule|constitution`. No compatibility aliases — scripts
  and docs must use the new paths (see [ADR 0005](docs/adr/0005-nested-agent-asset-operations.md)).

## Changes

- **Nested agents CLI**: `add` and `remove` sub-apps expose `skill`/`rule`/`constitution`;
  `quickstart` stays at the `agents` level. Add stays thin (resolve → install); remove
  follows validate → per-candidate confirm → mutate.
- **Safe asset removal**: every detected target is confirmed individually before deletion.
  Constitution removal is conservative — user-authored `AGENTS.md`/`CLAUDE.md` is skipped
  unless `--force`, and a mixed `CLAUDE.md` has only its `@AGENTS.md` import stripped
  (file kept, reported as "Updated:").
- **Quickstart conflict resolution**: all conflicts are surfaced during the prompt
  collection phase before any mutation, so Abort leaves the project untouched
  (see [ADR 0006](docs/adr/0006-conflict-resolution-in-prompt-collection-phase.md)).
- **`--no-uv-init` flag**: uv-init is now a first-class, opt-out-able quickstart step.
  This unblocks non-interactive runs on an already-initialized project, which previously
  hard-aborted at the uv-init conflict with no way to skip.
- **Non-TTY behavior**: removal confirmations and unresolved conflicts abort cleanly with
  guidance in a non-TTY shell, instead of a bare `KeyboardInterrupt`/exit-130.
- **Bundled `github-issue-workflow` skill**: added for both Cursor and Claude providers.
- **logger**: questionary prefix fix; `confirm`/`checkbox`/`select` raise on cancel.
- **Docs**: new domain terms in `CONTEXT.md` (Conflict, Conflict Resolution, Abort,
  Detected Agent Asset), ADRs 0005 & 0006, and `system-architecture.md` updates.

## Review hints

- **`utils/agents.py` `remove_constitution_file`** is the trickiest logic: catalog-match
  detection, the import-stub vs. mixed-`CLAUDE.md` branches, backup, and the
  removed/modified/skipped action mapping. Worth careful reading.
- **`project_app.py` `_resolve_conflict` + the uv-init gate** encode the
  abort-before-mutation contract; confirm the non-TTY and `--no-uv-init` paths read
  correctly.
- **`agents_app.py` `_build_removal_candidates` / `_confirm_removal_candidates`**: dedup
  by path and the confirmed/skipped re-match.
- No DB or network changes; asset install source remains the bundled catalog only.
- Path traversal was reviewed and is not reachable (names validated against the catalog /
  detected on-disk components).
