### PR TITLE
fix: siesta .gitignore precedence over uv init + label agent-asset tree entries

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -39,7 +39,7 @@ User interruption during prompt collection that exits with code 130 at the CLI e
 _Avoid_: abort, quit
 
 **Conflict**:
-An existing artifact on disk that a Mutation would overwrite or corrupt if run unconditionally.
+An artifact that existed on disk _before the run started_ and that a Mutation would overwrite or corrupt if run unconditionally. Scope is pre-run: an artifact a prior Mutation produced within the same run (for example the `.gitignore` that `uv init` writes during `quickstart`) is not a Conflict — it is a byproduct of the pipeline, and a later step that owns that artifact may overwrite it freely.
 
 **Conflict Resolution**:
 The sub-process within the Prompt Collection Phase where each detected Conflict is surfaced to the user, who declares skip, overwrite, or abort. All Conflict Resolutions are collected before the first Mutation — guaranteeing that Abort leaves the project state identical to its pre-run state.

--- a/src/siesta/cli/project_app.py
+++ b/src/siesta/cli/project_app.py
@@ -331,7 +331,11 @@ def quickstart_project(
             "Would you like to initialize the ``.gitignore`` file?", "gitignore"
         )
     gitignore_overwrite = False
-    if gitignore and Path(".gitignore").exists():
+    # Capture pre-run existence: only a .gitignore present before any Mutation is a
+    # Conflict. The one `uv init` writes during the Execution Phase is a pipeline
+    # byproduct, so siesta's gitignore takes precedence over it (see CONTEXT.md).
+    gitignore_preexisted = Path(".gitignore").exists()
+    if gitignore and gitignore_preexisted:
         result = _resolve_conflict(".gitignore", overwrite)
         if not result:
             gitignore = False
@@ -455,7 +459,9 @@ def quickstart_project(
         logger.info("Test actions config written.")
 
     if gitignore:
-        write_gitignore(overwrite=gitignore_overwrite)
+        # Overwrite when the file was not a pre-run Conflict: any .gitignore on disk
+        # now was written by `uv init` this run, and siesta's takes precedence.
+        write_gitignore(overwrite=gitignore_overwrite or not gitignore_preexisted)
         logger.info("Gitignore written.")
 
     if docs:

--- a/src/siesta/utils/tree.py
+++ b/src/siesta/utils/tree.py
@@ -16,11 +16,15 @@ BRANCH = "│   "
 TEE = "├── "
 LAST = "└── "
 TREE_LABELS = {
+    ".claude/": "Claude agent assets: skills and rules.",
+    ".cursor/": "Cursor agent assets — same structure as .claude/.",
     ".git/": "Contains the git data repository for your project. Do NOT touch this folder.",
     ".github/": "Contains the GitHub Actions workflows for your project.",
     ".gitignore": "Specifies files and directories that should be ignored by git.",
     ".pre-commit-config.yaml": "Contains the 'hooks', i.e. routines, that are executed before each commit.",
     ".readthedocs.yaml": "Config file to deploy your docs to ReadTheDocs (ask Victor).",
+    "AGENTS.md": "Always-loaded instructions for AI coding agents; the source of truth.",
+    "CLAUDE.md": "Claude's entry point — imports AGENTS.md (keep edits in AGENTS.md).",
     "docs/": "Contains the documentation for your project.",
     "docs/source/": "Contains the documentation's source code that will be rendered by Sphinx.",
     "docs/source/conf.py": "Configures your Sphinx-based documentation.",

--- a/tests/test_cli/test_quickstart_project.py
+++ b/tests/test_cli/test_quickstart_project.py
@@ -509,6 +509,77 @@ def test_quickstart_no_uv_init_on_fresh_project_warns(
     assert "Skipping uv init on a fresh directory" in output.getvalue()
 
 
+def test_quickstart_gitignore_takes_precedence_over_uv_init(
+    tmp_path_chdir, monkeypatch
+):
+    """A fresh quickstart overwrites the .gitignore that uv init writes mid-run.
+
+    The file does not pre-exist the run, so it is not a Conflict — siesta's
+    .gitignore takes precedence and write_gitignore is called with overwrite=True.
+    """
+    overwrites: list[bool] = []
+    monkeypatch.setattr(cli, "get_project_name", lambda _interactive: "test_siesta")
+    monkeypatch.setattr(cli, "run_command", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(
+        cli, "write_gitignore", lambda overwrite=False: overwrites.append(overwrite)
+    )
+    monkeypatch.setattr(cli, "tree_project", lambda *_args, **_kwargs: None)
+
+    try:
+        app(
+            [
+                "project",
+                "quickstart",
+                "--no-deps",
+                "--no-precommit",
+                "--no-tests",
+                "--no-actions",
+                "--no-docs",
+                "--no-agents",
+            ]
+        )
+    except SystemExit as e:
+        assert e.code == 0
+
+    assert overwrites == [True]
+
+
+def test_quickstart_preexisting_gitignore_is_a_conflict(
+    tmp_path_chdir, monkeypatch, capture_output
+):
+    """A .gitignore present before the run is a Conflict; --no-overwrite skips it."""
+    (tmp_path_chdir / ".gitignore").write_text("# user's own\n")
+    monkeypatch.setattr("sys.stdin", io.StringIO())
+    called: list[bool] = []
+    monkeypatch.setattr(cli, "get_project_name", lambda _interactive: "test_siesta")
+    monkeypatch.setattr(cli, "run_command", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(
+        cli, "write_gitignore", lambda overwrite=False: called.append(overwrite)
+    )
+    monkeypatch.setattr(cli, "tree_project", lambda *_args, **_kwargs: None)
+
+    with capture_output():
+        try:
+            app(
+                [
+                    "project",
+                    "quickstart",
+                    "--no-overwrite",
+                    "--no-deps",
+                    "--no-precommit",
+                    "--no-tests",
+                    "--no-actions",
+                    "--no-docs",
+                    "--no-agents",
+                ]
+            )
+        except SystemExit as e:
+            assert e.code == 0
+
+    # Pre-run Conflict + --no-overwrite => the existing file is kept, no write.
+    assert called == []
+
+
 def test_quickstart_respects_no_agents(tmp_path_chdir, capture_output):
     """--no-agents skips the agent assets step."""
     with capture_output():

--- a/tests/test_utils/test_tree_utils.py
+++ b/tests/test_utils/test_tree_utils.py
@@ -145,3 +145,13 @@ def test_label_tree():
         ),
         split_new_lines=True,
     )
+
+
+def test_agent_asset_labels_present():
+    """Agent asset files/dirs installed by quickstart are labeled in the tree."""
+    for key in ("AGENTS.md", "CLAUDE.md", ".claude/", ".cursor/"):
+        assert key in TREE_LABELS
+    # CLAUDE.md points back to AGENTS.md (the Constitution's source of truth).
+    assert "AGENTS.md" in TREE_LABELS["CLAUDE.md"]
+    # .cursor/ defers to .claude/ rather than duplicating its description.
+    assert ".claude/" in TREE_LABELS[".cursor/"]


### PR DESCRIPTION
## What

Two small, independent fixes in `siesta project quickstart`:

1. **`.gitignore` precedence over `uv init`.** On a fresh project, `uv init` writes its own `.gitignore` during the Execution Phase. `write_gitignore` then saw a file on disk and skipped, so siesta's `.gitignore` never landed — uv's won silently.

   The fix treats *pre-run existence* as the **Conflict** boundary: a `.gitignore` present before the run is still a Conflict (Conflict Resolution / `--overwrite` unchanged), but the one `uv init` produces mid-run is a pipeline byproduct, so siesta overwrites it. Opt out with `--no-gitignore` (keeps uv's, writes nothing). `CONTEXT.md`'s **Conflict** definition is updated to make the pre-run scope explicit.

2. **Tree labels for agent assets.** `quickstart` installs the cursor + claude assets and then prints the project tree, but `AGENTS.md`, `CLAUDE.md`, `.claude/` and `.cursor/` had no labels. Added them — distinguishing `AGENTS.md` (source of truth) from `CLAUDE.md` (its `@AGENTS.md` import stub); `.cursor/` points to `.claude/` for structure instead of duplicating the description.

## Tests

- `test_quickstart_gitignore_takes_precedence_over_uv_init` — fresh run calls `write_gitignore(overwrite=True)`.
- `test_quickstart_preexisting_gitignore_is_a_conflict` — pre-run file + `--no-overwrite` → skipped.
- `test_agent_asset_labels_present` — the four new labels exist and don't duplicate.

All quickstart + tree tests pass; ruff check/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)